### PR TITLE
Update aws-lambda-java-log4j2 and log4j

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -47,10 +47,10 @@ dependencies {
     implementation("com.amazonaws:aws-lambda-java-events:2.2.1")
 
     // lambda logging
-    implementation("com.amazonaws:aws-lambda-java-log4j2:1.2.0")
-    implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.13.0")
-    implementation("org.apache.logging.log4j:log4j-core:2.13.2")
-    implementation("org.apache.logging.log4j:log4j-api:2.13.0")
+    implementation("com.amazonaws:aws-lambda-java-log4j2:1.3.0")
+    implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.15.0")
+    implementation("org.apache.logging.log4j:log4j-api:2.15.0")
 }
 
 // need to exclude "parent" dependencies to avoid clash upon copy / zip of the final layer


### PR DESCRIPTION
See https://aws.amazon.com/security/security-bulletins/AWS-2021-005/

`Customers using the aws-lambda-java-log4j2 (https://repo1.maven.org/maven2/com/amazonaws/aws-lambda-java-log4j2/) library in their functions will need to update to version 1.3.0 and redeploy.`