### PR TITLE
Add Splunk notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,5 @@ OTEL_TRACES_EXPORTER: jaeger-thrift-splunk
 ## License and versioning
 
 The project is released under the terms of the Apache Software License version 2.0. For more details, see [the license file](./LICENSE).
+
+>ℹ️&nbsp;&nbsp;SignalFx was acquired by Splunk in October 2019. See [Splunk SignalFx](https://www.splunk.com/en_us/investor-relations/acquisitions/signalfx.html) for more information.


### PR DESCRIPTION
This small PR adds the acquisition notice with a link to the README file.