### PR TITLE
Update splunk-otel-python version to 1.7.0

### DIFF
--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -8,7 +8,7 @@ echo "Modify dependencies and script for Splunk integration"
 pushd "$OTEL_PYTHON_DIR"
 
 cd "$SOURCES_DIR"
-sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.5.0/g' requirements.txt
+sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.6.0/g' requirements.txt
 sed -i 's/^docker run --rm/docker run/g'  ../../build.sh
 sed -i 's/opentelemetry-instrument/splunk-py-trace/g'  otel-instrument
 echo "Modified python wrapper requirements:"


### PR DESCRIPTION
Replaces #78 

I figured it was worth opening a PR to the latest release just in case the protobuf issue was fixed elsewhere.