### PR TITLE
feat(nodejs): Add instrumentation for Winston log library

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -637,6 +637,14 @@
         }
       }
     },
+    "@opentelemetry/instrumentation-winston": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.28.0.tgz",
+      "integrity": "sha512-NJESVbQiKOt78R7xoRTHQ32gysMH5VsU6EzdwoB5UHtVa4/GXPhisyZUpxSOcukYBbhrwn0orHTypOwko2bD7Q==",
+      "requires": {
+        "@opentelemetry/instrumentation": "^0.28.0"
+      }
+    },
     "@opentelemetry/otlp-exporter-base": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.28.0.tgz",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -47,6 +47,7 @@
     "@opentelemetry/instrumentation-net": "0.28.0",
     "@opentelemetry/instrumentation-pg": "0.28.0",
     "@opentelemetry/instrumentation-redis": "0.28.0",
+    "@opentelemetry/instrumentation-winston": "0.28.0",
     "@opentelemetry/resource-detector-aws": "1.1.2",
     "@opentelemetry/resources": "1.1.0",
     "@splunk/otel": "1.4.1",

--- a/nodejs/src/wrapper.ts
+++ b/nodejs/src/wrapper.ts
@@ -36,6 +36,7 @@ import { MySQLInstrumentation } from '@opentelemetry/instrumentation-mysql';
 import { NetInstrumentation } from '@opentelemetry/instrumentation-net';
 import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
 import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis';
+import { WinstonInstrumentation } from '@opentelemetry/instrumentation-winston';
 
 const { AwsInstrumentation } = require('@opentelemetry/instrumentation-aws-sdk');
 
@@ -134,6 +135,7 @@ const instrumentations = [
   new NetInstrumentation(),
   new PgInstrumentation(),
   new RedisInstrumentation(),
+  new WinstonInstrumentation(),
 ];
 
 async function initializeProvider() {


### PR DESCRIPTION
Adds instrumentation support for the [Winston](https://www.npmjs.com/package/winston) logging library for NodeJS via inclusion of the [@opentelemetry/instrumentation-winston](https://www.npmjs.com/package/@opentelemetry/instrumentation-winston) dependency.