### PR TITLE
Update otel-sqs-handler script with splunkitude

### DIFF
--- a/java/build-layer.sh
+++ b/java/build-layer.sh
@@ -31,9 +31,11 @@ rm opentelemetry-java-wrapper.zip
 sed -i '2isource /opt/splunk-default-config' otel-handler
 sed -i '2isource /opt/splunk-default-config' otel-stream-handler
 sed -i '2isource /opt/splunk-default-config' otel-proxy-handler
+sed -i '2isource /opt/splunk-default-config' otel-sqs-handler
 sed -i '3isource /opt/splunk-java-config' otel-handler
 sed -i '3isource /opt/splunk-java-config' otel-stream-handler
 sed -i '3isource /opt/splunk-java-config' otel-proxy-handler
+sed -i '3isource /opt/splunk-java-config' otel-sqs-handler
 # proxy handler has one more special change
 sed -i 's/io.opentelemetry.instrumentation.awslambdaevents.v2_2.TracingRequestApiGatewayWrapper/com.splunk.support.lambda.TracingRequestApiGatewayWrapper/g' otel-proxy-handler
 


### PR DESCRIPTION
Upstream `otel-sqs-handler` needs our script modifications for environment variables.  Note that this PR isn't trying to test or verify Java Lambda SQS triggers, just do the minimum groundwork to make that possible.