### PR TITLE
Apr 2023 dependency/version updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,13 @@ jobs:
   check-links:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - name: Check all links in *.md files
         id: lychee
-        uses: lycheeverse/lychee-action@v1.5.4
+        uses: lycheeverse/lychee-action@v1.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/java/build-layer.sh
+++ b/java/build-layer.sh
@@ -14,10 +14,11 @@ mkdir -p $OTEL_JAVA_DIR/layer-wrapper/build/extensions
 # FIXME adding our stuff as an extension causes duplicate entry
 # build errors, but what libs are actually needed to copy through here?
 # What is provided by sdk runtime to the extension (e.g., logging)?
-rm ./build/libs/opentelemetry-sdk-logs-1.22.0-alpha.jar
-rm ./build/libs/opentelemetry-api-logs-1.22.0-alpha.jar
-rm ./build/libs/opentelemetry-exporter-otlp-1.22.0.jar
-rm ./build/libs/opentelemetry-sdk-extension-autoconfigure-spi-1.22.0.jar
+rm ./build/libs/opentelemetry-sdk-logs-*.jar
+rm ./build/libs/opentelemetry-api-logs-*.jar
+rm ./build/libs/opentelemetry-api-events-*.jar
+rm ./build/libs/opentelemetry-exporter-otlp-*.jar
+rm ./build/libs/opentelemetry-sdk-extension-autoconfigure-spi-*.jar
 cp ./build/libs/*.jar $OTEL_JAVA_DIR/layer-wrapper/build/extensions
 
 echo "Building OTEL wrapper"

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -8,8 +8,8 @@ description = "Splunk distribution of OpenTelemetry Lambda"
 
 ext {
     versions = [
-            opentelemetry: '1.22.1',
-            opentelemetryalpha: '1.22.1-alpha'
+            opentelemetry: '1.24.0',
+            opentelemetryalpha: '1.24.0-alpha'
     ]
 }
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -43,16 +43,16 @@ dependencies {
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")
 
     // auto service (loaded by SDK)
-    annotationProcessor("com.google.auto.service:auto-service:1.0")
-    compileOnly("com.google.auto.service:auto-service:1.0")
+    annotationProcessor("com.google.auto.service:auto-service:1.0.1")
+    compileOnly("com.google.auto.service:auto-service:1.0.1")
 
     // AWS lambda
     // events
-    implementation("com.amazonaws:aws-lambda-java-events:3.11.0")
+    implementation("com.amazonaws:aws-lambda-java-events:3.11.1")
     // lambda logging
     implementation("com.amazonaws:aws-lambda-java-log4j2:1.5.1")
     implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.18.0")
-    implementation("org.apache.logging.log4j:log4j-core:2.19.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.20.0")
 }
 
 // need to exclude "parent" dependencies to avoid clash upon copy / zip of the final layer

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -10,40 +10,23 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api": "1.3.0",
-        "@opentelemetry/instrumentation": "0.34.0",
-        "@opentelemetry/instrumentation-aws-lambda": "0.34.0",
-        "@opentelemetry/instrumentation-aws-sdk": "0.10.0",
-        "@opentelemetry/instrumentation-dns": "0.31.0",
-        "@opentelemetry/instrumentation-express": "0.32.0",
-        "@opentelemetry/instrumentation-graphql": "0.33.0",
-        "@opentelemetry/instrumentation-grpc": "0.34.0",
-        "@opentelemetry/instrumentation-hapi": "0.31.0",
-        "@opentelemetry/instrumentation-http": "0.34.0",
-        "@opentelemetry/instrumentation-ioredis": "0.33.0",
-        "@opentelemetry/instrumentation-koa": "0.34.0",
-        "@opentelemetry/instrumentation-mongodb": "0.33.0",
-        "@opentelemetry/instrumentation-mysql": "0.32.0",
-        "@opentelemetry/instrumentation-net": "0.31.0",
-        "@opentelemetry/instrumentation-pg": "0.33.0",
-        "@opentelemetry/instrumentation-redis": "0.34.0",
-        "@opentelemetry/resource-detector-aws": "1.2.1",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-trace-node": "1.8.0",
-        "@splunk/otel": "2.1.0",
+        "@opentelemetry/instrumentation-aws-lambda": "0.35.0",
+        "@opentelemetry/resource-detector-aws": "1.2.2",
+        "@opentelemetry/sdk-trace-node": "^1.10.1",
+        "@splunk/otel": "^2.2.1",
         "@types/signalfx": "7.4.1"
       },
       "devDependencies": {
         "typescript": "4.9"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14"
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
-      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
+      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -53,9 +36,9 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.3.tgz",
-      "integrity": "sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.6.tgz",
+      "integrity": "sha512-QyAXR8Hyh7uMDmveWxDSUcJr9NAWaZ2I6IXgAYvQmfflwouTM+rArE2eEaCtLlRqO81j7pRLCt81IefUei6Zbw==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -155,100 +138,194 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
-      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
-    "node_modules/@opentelemetry/api-metrics": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz",
-      "integrity": "sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==",
-      "deprecated": "Please use @opentelemetry/api >= 1.3.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.8.0.tgz",
-      "integrity": "sha512-ueLmocbWDi1aoU4IPdOQyt4qz/Dx+NYyU4qoa3d683usbnkDLUXYXJFfKIMPFV2BbrI5qtnpTtzErCKewoM8aw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.12.0.tgz",
+      "integrity": "sha512-PmwAanPNWCyS9JYFzhzVzHgviLhc0UHjOwdth+hp3HgQQ9XZZNE635P8JhAUHZmbghW9/qQFafRWOS4VN9VVnQ==",
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.4.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-4DWYNb3dLs2mSCGl65jY3aEgbvPWSHVQV/dmDWiYeWUrMakZQFcymqZOSUNZO0uDrEJoxMu8O5tZktX6UKFwag==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.8.0"
+        "@opentelemetry/semantic-conventions": "1.12.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.4.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.34.0.tgz",
-      "integrity": "sha512-9INc1TBJ7OwpMsImqUjpPEvQeRyyU9tEiFQIYQ53kKQK7V8MqB5koyDeb5/qBSbNu4ZxSpukAOLPgBOEMDK6Qw==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.36.1.tgz",
+      "integrity": "sha512-yQPHny0Y3HIE1BSqbN82MoqqbbJeLINjL7Qf3kJwv1zt5YLUhYbn3FkqHQWS0YWpAvdjK0/OcN40SjEbVz2HRA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-metrics": "1.10.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
+      "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/resources": "1.10.1",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.34.0.tgz",
-      "integrity": "sha512-ToRJA4frErHGiKKnPCI3+cvdyK8rksRI+mV6xZ6Yt7HiIrArY9eDX7QaCEZcTLbQIib09LTlCX87TKEL3TToWQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.36.1.tgz",
+      "integrity": "sha512-JcpEBwtBpNhVvmCLH3zjTPDcOld2AeI5rNglv2JrB16QCxQ5pwsOgzw7mPe/UR4u/53Ij7LIjFTOCeyVto/6aA==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-metrics": "1.10.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
+      "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/resources": "1.10.1",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.34.0.tgz",
-      "integrity": "sha512-l9748EtVH+wl1MWFptiRdieS9OkZgGkG4jQRDj+BGIxKJifIiVu6E2o6y+31fkxVzpLAtcxjAG/far0HHpPeZg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.36.1.tgz",
+      "integrity": "sha512-dKJRKvIiyupuZJOVCzW9wNfsK6RxkELnzCSJHzFoIwhGRXSYpbWyYrfHj4ZJZWYZiQSJ7+I8BFUa4aSkBgnO0w==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-metrics": "1.10.1"
       },
       "engines": {
         "node": ">=14"
@@ -257,36 +334,142 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
+      "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/resources": "1.10.1",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.34.0.tgz",
-      "integrity": "sha512-x1V0daRLS6k0dhBPNNLMOP+OSrh8M60Xs9/YkuZS0+/zdbcIjNvPzo/8+dK3zOJx+j1KF0oBX9zxK0SX3PSnZw==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.36.1.tgz",
+      "integrity": "sha512-U2HdWvQho2VkeSAcAhkZ2wjfUb/1SKQixo5x6LNBF17ES4QYuh5+BagYxfN5FP4dbLnjZpTtFk5lj+97lfNLEw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-trace-base": "1.10.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
+      "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.34.0.tgz",
-      "integrity": "sha512-Ump/OyKxq1b4I01aBWSHJw8PCquZAHZh6ykplcmFBs9BZ8DIM7Jl3+zqrS8Vb7YcZ7DZTYORl8Xv/JQoQ+cFlw==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.36.1.tgz",
+      "integrity": "sha512-pNfrto7amygyyhmL4Kf96wuepROEecBYXSrtoXIVb1aUhUqjWLsA3/6DR3unB5EfSRA1Oq1Z9bqHfNuKqGfPNw==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-trace-base": "1.10.1"
       },
       "engines": {
         "node": ">=14"
@@ -295,10 +478,63 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
+      "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.35.1.tgz",
+      "integrity": "sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==",
       "dependencies": {
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
@@ -312,14 +548,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.32.0.tgz",
-      "integrity": "sha512-/JkDnNNXHBrmesXS826E2z8c/EZoClO4S8ckQzbqdLd+m+n4u9Q9q/9ZV7WWlSAd7BSt3GJNbcjwdxeA7FobKw==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.32.2.tgz",
+      "integrity": "sha512-NSXvRKtJhBqkKQltmOicg0ChyAA5VfrKPa9WSrFDXvlw8Pjs9UiQQTEYbiBT3V5LSjJXH6CpNnQp6v2bqEldow==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/amqplib": "^0.5.17"
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -329,12 +564,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.34.0.tgz",
-      "integrity": "sha512-y/Tn+sFTssJaEb9cJOU3BTxR7ZrVg+6v0cgCO46SIPahhNrDq1kbQ2fYIdG/EVfwbfJyn80bfOQvfE3hNflmeA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.35.0.tgz",
+      "integrity": "sha512-x6nd1DEf/MYU57AMphwyxQLSPSNit6lnJAMNz9eQmQ0TdzGaWUsWUz2OgoZXzjF2D8hbaJHYaDvl1IUOk7cNVg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.32.0",
-        "@opentelemetry/propagator-aws-xray": "^1.1.1",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/propagator-aws-xray": "^1.2.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/aws-lambda": "8.10.81"
@@ -346,31 +581,14 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-aws-lambda/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
-      "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
-      "dependencies": {
-        "@opentelemetry/api-metrics": "0.32.0",
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.10.0.tgz",
-      "integrity": "sha512-8LJfZjoca9Dn+U19mPGjtKGstUrCj5/cRithJCJxrab24Cyry4DnNqltTrXUGIE5Y6XNxX4VXQHiJC/EYyl/CQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.34.0.tgz",
+      "integrity": "sha512-DT7Z08MVNOk/kyvztV1l4s1YMjW4qTbw852EhKkgpyYeKkxfGwdHqvv6+7MzOboJPXFQv/ADn1zcPtD8Lqia/Q==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/propagation-utils": "^0.29.1",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/propagation-utils": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -381,11 +599,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.31.0.tgz",
-      "integrity": "sha512-yehA39p7olnrfBp4VDmOrK/vvMIvmT/8euimRRpQNa/bAPE7vQnbHokfOxsIXIKYqJdhEc9Rxc5pJ7StTrS7wA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.31.1.tgz",
+      "integrity": "sha512-y81y0L50ocziES+jVcsCM684R+1p3M64bfGwVumZI/cH3LNSlnvOd4xgQom4Ug+UzcYcP9RxjFURDQAvh8tnDw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@types/bunyan": "1.8.7"
       },
       "engines": {
@@ -396,11 +614,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.32.0.tgz",
-      "integrity": "sha512-5b68tqZDCRBFp8oQf7vN9RJY+UAfQyAxsrGiJBgGGK159nOIoHHBLjfM02A4rkmkPdJUNz3G02jkFbHFUN/vnw==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.32.1.tgz",
+      "integrity": "sha512-28tbhM8I7Yp7PfSRnykxMFHKDsJC5efwOOoI/CehxIITSLOLrenmCEeNhSUfVUHzMIiqFiZXW/F0wurbAy38pg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -411,12 +629,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.31.0.tgz",
-      "integrity": "sha512-7vzK3KQWjxY5yeTy+uqgclSxcS8qM8fnc2yO67EouHt6YNciJbL0pPKw1tGG6Yem/q5vr4qmFTFuYqjnD9Jq1Q==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.31.1.tgz",
+      "integrity": "sha512-72hDzkUIpq4TFrBi0yooNH/LVQbiGZ3wgL0uVGjvyTfN1ZOfoa5LhverWwtfAcjn1aniVU4xEL6aWqGl0A3nDQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.35"
       },
@@ -428,11 +646,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.3.0.tgz",
-      "integrity": "sha512-dV/EXnFrztisi3GXmv9WoweCiw5j02fPZwUKP5VzwqlJFHOy1x4U8qxzhkOYZF4nJFI4X70F2oHXDE1Ah0TRkg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.4.0.tgz",
+      "integrity": "sha512-t12pWySH7d5Kmo9CZDAPs22d40kzWHyvMFsQGysc7UVtBOXB+Vg7Bzt4j3R4jdal/WkGKRgXL920zhGmziuzxw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0"
+        "@opentelemetry/instrumentation": "^0.35.1"
       },
       "engines": {
         "node": ">=14"
@@ -442,11 +660,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.31.0.tgz",
-      "integrity": "sha512-enaXHCdKPOm8eaRddw3ZA1DDU+7E7fGJs2EuhFi2xlzdyWs6luoycVZaJ2cPvJlNWJLrhBPtyGH6qbxoVi/5FQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.31.2.tgz",
+      "integrity": "sha512-BBfMzbJGdEEz/OX2uPq0u9NAX2HL9KZ5x3PqwnJEqnUnRBr8hHJ9xbbY9WKRxZ55cGt8XeQpkj2NbRNkoy4hzQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.3.2"
       },
@@ -458,12 +676,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.32.0.tgz",
-      "integrity": "sha512-t2QOKwaZXUXQSJn4G90THpOyxyNBUyK0B059PUQpOqc/uybUo0SI8edfVlYRlcfHadG+S0fnU8QvnldmZ8AJqA==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.32.1.tgz",
+      "integrity": "sha512-MR5ondudJaBG+GscjTWp3dm+mUacWgD9CnFs+EURNzd4EfHpPcxB9ZtFgUfzsp6FMJQZvOsgN5/fHQ4wmkf/fg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
       },
@@ -475,12 +693,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.31.0.tgz",
-      "integrity": "sha512-HLKoG3ZY8hgK/xHwTy4CD/ybAc+cRkjal4AEE978vVeV8ArUfiN7SwQu5P97kW03lIpzJ8IDtk8UewpNe8VWyA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.31.1.tgz",
+      "integrity": "sha512-oROINVKIvkkX3wQidPOYH78ruHwvfVBIi74svkeNaMzZ78xW2Djb/BiA5tXAujhi+fRGl2kwCG580iS9q5G7YA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -491,11 +709,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.31.0.tgz",
-      "integrity": "sha512-XbF07I0uSfGbPHqjx86LIQWllY0lfIXM0yIpFMxqiW6OY7xRdk6GWcvKmUq/eU+3ZYrLb2nn9EqUpWDMWDnejg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.31.1.tgz",
+      "integrity": "sha512-FvoQKVpafcXvsJvIQU3QOFx/KBwbCblIGW83JWwoz2ymMu1coSJTveqN7cNVqEMR3BZ0eN4Ljgmq3AvimWXiTg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/generic-pool": "^3.1.9"
       },
@@ -507,11 +725,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.0.tgz",
-      "integrity": "sha512-d3Qv847LI5JLJF3iR9+86V7K/+nUqVkNu2XJ1L1/4Ze5sih1R+722tx7IrS7UEDkkoNI0E0m74Yg9pJ0kwXMTQ==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.2.tgz",
+      "integrity": "sha512-LDtPV01e8CHeCWS1Y0FL/katkdlsgvYUaPkZBL72k8F3Rm/rEYCBlswUwBJaBoRLxBY7jlwEm3fiGcTxsFyvSg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0"
+        "@opentelemetry/instrumentation": "^0.35.1"
       },
       "engines": {
         "node": ">=14"
@@ -521,12 +739,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.34.0.tgz",
-      "integrity": "sha512-IqwWq5d3Jiah0eSm1IH6K32rYKe4nnMKkm7qV6ISwWhFFtUPfuOatUKAttmuvipvPCuxiiIS2P/zbmytkwmFVg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.35.1.tgz",
+      "integrity": "sha512-EBmpCD+5QfUXPmupynjwxt3tUG5bgTrGZT12B0/+By9ZMLboDAryHjpiermanbPh5mTOq0q73YzruGQWU9TExg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.34.0",
-        "@opentelemetry/semantic-conventions": "1.8.0"
+        "@opentelemetry/instrumentation": "0.35.1",
+        "@opentelemetry/semantic-conventions": "1.9.1"
       },
       "engines": {
         "node": ">=14"
@@ -535,13 +753,21 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
+      "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.31.0.tgz",
-      "integrity": "sha512-+VPnZFRfXeZpF0WuaCym9mPkjQyJa8t0S/qw7v5OWs6w64VLyT7mFLh6dChYoivwx8N0p+TaO/l/Bb+e4y/neg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.31.1.tgz",
+      "integrity": "sha512-kk/LdhIb/5AC48xHq1LzoV6My7TgEAANxsIXQwLiIUVBgM5yjH3bEb5TjyqbSVNvqsJ1aU5etQICjKbSNh+zlA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.9"
       },
@@ -553,13 +779,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.34.0.tgz",
-      "integrity": "sha512-sZxpYOggRIFwdcdy1wWBGG8fwiuWWK4j3qv/rdqTwcPvrVT4iSCoPNDMZYxOcxSEP1fybq28SK43e+IKwxVElQ==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.35.1.tgz",
+      "integrity": "sha512-tH92LznX5pcxpuTSb6A662IdldlMk8QTtneDN66h4nIT9ch98Gtu68GSSKjMoTR25GzH3opvPC9mX2xJamxMJw==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/instrumentation": "0.34.0",
-        "@opentelemetry/semantic-conventions": "1.8.0",
+        "@opentelemetry/core": "1.9.1",
+        "@opentelemetry/instrumentation": "0.35.1",
+        "@opentelemetry/semantic-conventions": "1.9.1",
         "semver": "^7.3.5"
       },
       "engines": {
@@ -569,14 +795,37 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.33.0.tgz",
-      "integrity": "sha512-RhsR3PFdUNiNGnGPVoNpjrsoNWxKrdyAqSOaodE1uoVsJrVBIEKNCD4P82ccTjCuQHsa8ni0/DCt4Cxq7oNG3g==",
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
+      "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-ioredis": {
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.34.0.tgz",
+      "integrity": "sha512-2oEOcsqBHGxt4fDV3lM8vxCZNKv2E7ChChSctu4IPem4ixT4vCBm1oEVDU2/6RcS6vnNS6XtbhCchQtKjUMQyA==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/redis-common": "^0.35.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/ioredis": "4.26.6"
+        "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
       },
       "engines": {
         "node": ">=14"
@@ -586,11 +835,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.0.tgz",
-      "integrity": "sha512-BqEFTckHDYgD9sPNhdkoL5BHbGevFoPK2XTKBTZah2DR4rD48G8ntsE8K6kt17lA1Q1jgdqe4U690UxGC6/m3g==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.1.tgz",
+      "integrity": "sha512-X9SIdzmyyoknPwUB+/JfcF8VHujQWxXDNMKl3PpxU2PwEaKpXPKtOgdA7do08tSoULMI0xCftFIzBUFnWivPFQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -601,14 +850,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.0.tgz",
-      "integrity": "sha512-+ZLABLbe08U6Xg8Eyu0AJCjchk9Kpah8lUEAUhaNdY2M5RdEqlm4LkvlCdmq425KzsrTX0AeWaCfcvGqFr4+lw==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.3.tgz",
+      "integrity": "sha512-WHPl7MMmeFeM1Mg9kgCU64Zdc6MXwXXw9qnJV4Ajl/7zX6/XyGEatDcTMxaJAzVQKXSHR70lKfl8+/W/UP2wrw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/koa": "2.13.4",
+        "@types/koa": "2.13.6",
         "@types/koa__router": "8.0.7"
       },
       "engines": {
@@ -619,11 +868,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.31.0.tgz",
-      "integrity": "sha512-wkoZQ6TyHWuaHTmV/MSIqJzFyEnjWj6hdRftX6eJUv1xalYjrxDZW6gFiByRdlVKupuksIW3/ntvozyLhzbJqQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.31.1.tgz",
+      "integrity": "sha512-uDiLLTsXlXLIvwYdl9+1AvxvWZkYrXAIvHwPOi6FthznnDIJtyxk0DgxusUaezhRUS9W1CqO5hFb1+8Hmg5DCQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       },
@@ -635,11 +884,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.33.0.tgz",
-      "integrity": "sha512-bjRF55grOFRn5XQxm1yDL56FD9UVvmIcBDSsgA0dbUr3VOUu3sN7o34t2uDx7EpnfwhMeAvOBO1wbWXdHBzapg==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.34.1.tgz",
+      "integrity": "sha512-zRmotNkUQF6G9KWMEr2K2xZSqlaYKLY4HvV+DGHtOeJ1NbRUFk0V5XBNpB6nc4dXiEJUlGfXRyrQ/yu5TKiUuA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -649,14 +898,31 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.32.0.tgz",
-      "integrity": "sha512-9BGbc0wiNokflUKmI3WEOnmCqp9QffcnrIoIs2cjqQekZGAzSmL7tyyL3SoW/qXWOUP8FM+OuEomklujNOZYbg==",
+    "node_modules/@opentelemetry/instrumentation-mongoose": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.32.1.tgz",
+      "integrity": "sha512-ibTM94JpTM6nbfARoql0wLWFOOchCIlDAhSibFNxQ+TImWLZxVQ6NpNnrtbrNoUoPD0xnB/ZlYR7as72Xu4Vyg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.33.0.tgz",
+      "integrity": "sha512-dU0phFuwtI81M7HyHbr/N4OllEAWYbQaOtSaJnDPMCxy4f840Np1kPzcTcAqd6zYIMhaO3B1nt7N2cP3ftu2RQ==",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/mysql": "2.15.19"
+        "@types/mysql": "2.15.19",
+        "mysql": "2.18.1"
       },
       "engines": {
         "node": ">=14"
@@ -666,11 +932,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.33.0.tgz",
-      "integrity": "sha512-DVWkr/WkALmIdtLoiVp/vgZVOXUCFvnlKOEz+LOQMHOktm0FLhdHRjX7jJhtVtEO7DdZQRnfpUYv8zP37gMawQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.33.1.tgz",
+      "integrity": "sha512-ZyGg2KAaQRTctjCUIo+s25Yl4WDAvReF//EA0vKb9nKxMafon1NEbWeO1+qIE6xiXRXFUFn80hnf0N/YLu5gvw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -681,11 +947,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.0.tgz",
-      "integrity": "sha512-kpzegHf1tNqtZhC+BCM/B9n3/e+vBYYYGZK+HUgiL/lHUoUf3Lsj6869eckSgucrScLjDGNBuo5j8JAkdNJ5zw==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.2.tgz",
+      "integrity": "sha512-nUidxCbRnN+QUKArl5f8rE3hkYTsYlHEZRoWMqH9fFsVxOdZ4S6kT/HP55/Pj9+cDZ6XfBbelEOZjpsYeO2dYg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -696,11 +962,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.31.0.tgz",
-      "integrity": "sha512-uzgI0AMZWYqN/w8oQ3EwSpFKnZ+yMVbzoRczh8pVZgWR8Xw35/h9GfgrOO2Sb9/4nf75bwO83hjRkW4KfsEE7w==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.31.1.tgz",
+      "integrity": "sha512-Gfks0UUi076w7aSTX1Q7KfnmlSqt0vMX0sc6jUWRd/BOQo/r84aS/DU0dP1FuPLyC4Vzpx9pPCnD37MRPhbkKA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -711,11 +977,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.33.0.tgz",
-      "integrity": "sha512-RYs4xsGkIKM5cw/3WPRKxjDyLd1DXhwYaNugJlbozDzkToZ1SRzd8I2qAJ2nTTKHtFrWYCqZILPXnRguZNHmnA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.35.0.tgz",
+      "integrity": "sha512-vNcnILF9c+SJVZr0R0xKY9HzbATLwRVbKrrIbkD6Oj4uzfarlA6n2bF3LJAYGMMcDSdxUN+KaTMeW9byLKqqTg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
@@ -728,11 +995,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.33.0.tgz",
-      "integrity": "sha512-2ZU6ri1/90UpLIZGIeF48BG58mZEtHBUgxYPj08J+HbatHkLg5RQtIy0Q9P9UbAAq+2+Izh2RDm5K1T5OVGkMg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.33.1.tgz",
+      "integrity": "sha512-Rajum1USKFE3khFSg7JRqoI+2BK2BpC2SiB0mjXdQ5s31IxaNuc6qiXdNz6mRzbdzMb/ydsJchlQiSNwB2iVeQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0"
+        "@opentelemetry/instrumentation": "^0.35.1"
       },
       "engines": {
         "node": ">=14"
@@ -742,13 +1009,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.34.0.tgz",
-      "integrity": "sha512-fUrU3Ekhxu6bcnurP/rfhZJNxQV9qUP2vQSQSRwPiPZs+s3UKuY19rQEFCST10jF66rQrqB32VwnGqeQyZbHlw==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.34.4.tgz",
+      "integrity": "sha512-X1iX75gcQGImLRGZ7s7vbgKy3zIwgZO9fECq7jDnSjBoQ2WxTs8BMN/J2wqEE4SUawxzbHxQqcvAXEy3zA4r0A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/redis": "2.8.31"
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/redis-common": "^0.35.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -758,11 +1025,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.34.0.tgz",
-      "integrity": "sha512-b3joRK8+aSszaznUoL8vtZrwreN/CJY0VZbmE3HE8IUvOc6W0QRvOl7fDAJ2z56lDT0f7cZSV05gpvslXgZeWg==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.34.3.tgz",
+      "integrity": "sha512-JdHK/retw8rttFkv393P07PEtxhaPLbWXWSJC8Y9kBAoZ+vFEMTM5z+vPQTfgcBQFveyy6v6GEa6H1ozd35z7w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/redis-common": "^0.35.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -773,12 +1041,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.31.0.tgz",
-      "integrity": "sha512-b0AWFZ9+tm4Iaydt1AquBpsQty+Uv1YQ3C9Jb4/JTknWDWW63tb8FoCcALMPYDulvOgH+PPDvtvZY0Q0Imbstg==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.32.1.tgz",
+      "integrity": "sha512-eko2ESs93LA8G81+qaVsDsCMdvDvvtWJKILBbqJAUeas0WqdLvytcMv/KlXGrHkenTtHA+t1pyTOPw4uyxELsQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -789,11 +1057,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-router": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.32.0.tgz",
-      "integrity": "sha512-s7RywETzH4FW+8yzPqbBYh5BdtILjM9cjhofucVXDcKY3tNSJA1gGBTCDOK49+ec9zyo1e+nchiYaeS9IW8U/A==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.32.1.tgz",
+      "integrity": "sha512-hLj2+Io3jaLfknaXOLhZc/ITs0St29Kf/LGIpfUA067JKtf9YSXndlfvI731nFf6O0KzKWc9loD/mKvc9W4bWQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
@@ -804,11 +1072,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.5.0.tgz",
-      "integrity": "sha512-PaaB56cggwg69JPTi3CYR0JnXV+hjBFAnkhKKwIKeaiHew7txOfPZo8S1cEW058jOPFySV+Qg8ZkGApXkvp5zg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.5.1.tgz",
+      "integrity": "sha512-iDDF/ZtxoV6eGzOjVj5qnHJ88RpTg7SbRnrFjPQ4E8HaNEjlnMnig3LjIKESV6GZpPO2DVciqIBWSfs8x34RIw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/tedious": "^4.0.6"
       },
@@ -820,11 +1088,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.31.0.tgz",
-      "integrity": "sha512-+19vD2v9wWuUP4Hz0dHcpeT5/5Ke0dtIeZ+zCFXJA4lLLR9QeKMN0ORFlbpAOBwKjjuaBHXnMAwuoMSdOUxCKw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.31.1.tgz",
+      "integrity": "sha512-qPK89Fp5bI6+IGMm2J2+A4kmeRfvRdrfgdwYlXoMZhO4aLL6BL5thdPYkDmIKO4FIzoOmybg62H3lMAExUUAyA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0"
+        "@opentelemetry/instrumentation": "^0.35.1"
       },
       "engines": {
         "node": ">=14"
@@ -834,44 +1102,88 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-xVNvQm7oXeQogeI21iTZRnBrBYS0OVekPutEJgb7jQtHg7x2GWuCBQK9sDo84FRWNXBpNOgSYqsf8/+PxIJ2vA==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.36.1.tgz",
+      "integrity": "sha512-fpjPwLafJIjgxY5qx7Ly74AYmRCd9spC6/jCxvEgGheg1YT4+NkfVnrfllxLRgc9wQNhDj7Y0Knp8RcmXLLVfA==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0"
+        "@opentelemetry/core": "1.10.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-8k3CIVjf2+/kmnQNKIR8GtPIfRsQ5ZxBVh3uKof54stVXH/nX5ArceuQaoEfFoFQ8S8wayBZ1QsBwdab65UK0g==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.36.1.tgz",
+      "integrity": "sha512-71TdQ3Z0D2Trq8rc2UMvky7tmIpg8kVPUhdYH3p0tNsTmbx6GDpEBOpjp2/zCFvQ0SZFVfHH2Oj2OZxZiz+FNQ==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.3",
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-qHnwcAafW8OKeM2a1YQNoL9/sgWVE+JxvMgxf2CtYBqsccIakGPoQ43hLCFLAL3I2Af4BNb5t4KnW8lrtnyUjg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.36.1.tgz",
+      "integrity": "sha512-9ErknJ5fS7r2NxEFeca93H+pGWnCjZCUWsz6Stcj5/z2rgsiZGHXLz3fQoUGQz+iXjiXKkks9wxTCRgWOW+Yiw==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "protobufjs": "7.1.1"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "protobufjs": "^7.1.2"
       },
       "engines": {
         "node": ">=14"
@@ -880,55 +1192,118 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-    },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/protobufjs": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-      "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
-      "hasInstallScript": true,
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
       "dependencies": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.34.0.tgz",
-      "integrity": "sha512-NghPJvn3pVoWBuhWyBe1n/nWIrj1D1EFUH/bIkWEp0CMVWFLux6R+BkRPZQo5klTcj8xFhCZZIZsL/ubkYPryg==",
-      "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0"
+        "@opentelemetry/semantic-conventions": "1.10.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.4.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.36.1.tgz",
+      "integrity": "sha512-d2MomkVHBHwfsmNz6E60s/sm7gtpSjFwDzkFLm9brVq//VXzEhaEyfYSeTabdUs4BmrzhqTIogHWlcd6cOiL+w==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-metrics": "1.10.1",
+        "@opentelemetry/sdk-trace-base": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
+      "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/resources": "1.10.1",
+        "lodash.merge": "4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
+      "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/semantic-conventions": "1.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.1.tgz",
-      "integrity": "sha512-sSlkke2RrUuWcbhsRUxbwn6G9XtPa1b8zUoudvxxwvs7nCPE2pQRy32JyqT7CbuWf6gQPK/R1u54T79c93oyGQ==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.2.tgz",
+      "integrity": "sha512-ynHFE2BMSZVK1Vq71qVJtdXQAt+pfYAYHHD+ZQYEKnkJN0F2GVMWz75JiHxh7wytt/maIqV9qcWxfjWFK1TUFw==",
       "engines": {
         "node": ">=14"
       },
@@ -937,9 +1312,9 @@
       }
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.1.1.tgz",
-      "integrity": "sha512-RExCA3v2/xZcGN//JaGIs/WXm2bs2z1YhvC07NG6SBF7Vyt5IGrDoHIQXb5raSP7RjYGbaJ7Qg7ND8qkWTXP6A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.2.0.tgz",
+      "integrity": "sha512-KCNFXdv63c+dItes2pUPVd1QDPmfcx3AVwcgE28emSx6tPI71q11zpMTDAWKPU8J9GQAGXMDyGnRGhIgua40aw==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0"
       },
@@ -951,37 +1326,45 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.8.0.tgz",
-      "integrity": "sha512-ffP6AVHyISqK1kiUY1MoVKt43Wp3FJXI8NOePqxBrAU7bRDJ13276VbSl4ugCZbZLTPrPhhSmvQh1WqlfUgcAg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.12.0.tgz",
+      "integrity": "sha512-WFcn98075QPc2zE1obhKydJHUehI5/HuLoelPEVwATj+487hjCwjHj9r2fgmQkWpvuNSB7CJaA0ys6qqq1N6lg==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0"
+        "@opentelemetry/core": "1.12.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.4.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.8.0.tgz",
-      "integrity": "sha512-v6GA38k2cqeGAh3368prLW5MsuG2/KxpfWI/PxTPjCa9tThDPq0cvhKpk7cEma3y+F6rieMhwmzZhKQL5QVBzQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.12.0.tgz",
+      "integrity": "sha512-ugtWF7GC6X5RIJ0+iMwW2iVAGNs206CAeq8XQ8OkJRg+v0lp4H0/i+gJ4hubTT8NIL5a3IxtIrAENPLIGdLucQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0"
+        "@opentelemetry/core": "1.12.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.4.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.35.0.tgz",
+      "integrity": "sha512-VgA1RN3wsfx1J9rgVOHkMESV9mB/mrRBTr24KNHtBY4jl8goKe/lmV1Qjjs6EUP8F78E/YJhezQCx9EtBOVweg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.2.1.tgz",
-      "integrity": "sha512-ryfMZ644kCLMs+PtoUeW8A5ewYEOm0UBnQJAuFnj2MPofA+pTrXEbfJ39kcVlH5qZKJR6xa9GNB1lRIEv2bA7w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.2.2.tgz",
+      "integrity": "sha512-DFnv0z+D+t224wOS+0rsEfvxqKLKFm0DYHDSuam68JKJ7pDbfpyBWhRc4fzDc/J6JT0LtPT4iMJcytQUiGEOwg==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -995,75 +1378,75 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
-      "integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.12.0.tgz",
+      "integrity": "sha512-gunMKXG0hJrR0LXrqh7BVbziA/+iJBL3ZbXCXO64uY+SrExkwoyJkpiq9l5ismkGF/A20mDEV7tGwh+KyPw00Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/semantic-conventions": "1.8.0"
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/semantic-conventions": "1.12.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.4.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.8.0.tgz",
-      "integrity": "sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.12.0.tgz",
+      "integrity": "sha512-zOy88Jfk88eTxqu+9ypHLs184dGydJocSWtvWMY10QKVVaxhC3SLKa0uxI/zBtD9S+x0LP65wxrTSfSoUNtCOA==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/resources": "1.12.0",
         "lodash.merge": "4.6.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.4.0"
+        "@opentelemetry/api": ">=1.3.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
-      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.12.0.tgz",
+      "integrity": "sha512-pfCOB3tNDlYVoWuz4D7Ji+Jmy9MHnATWHVpkERdCEiwUGEZ+4IvNPXUcPc37wJVmMpjGLeaWgPPrie0KIpWf1A==",
       "dependencies": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/semantic-conventions": "1.8.0"
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/resources": "1.12.0",
+        "@opentelemetry/semantic-conventions": "1.12.0"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.4.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.8.0.tgz",
-      "integrity": "sha512-6FqhJEgW9Nke5SO4Ul9+5EWOfms/JeLg5LRqILMPMK4UMBWcOtk7jldvGGyfVpraJ16/WPo/R5NSnMwlupN5zQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.12.0.tgz",
+      "integrity": "sha512-PxpDemnNZLLeFNLAu95/K3QubjlaScXVjVQPlwPui65VRxIvxGVysnN7DFfsref+qoh1hI6nlrYSij43vxdm2w==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.8.0",
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/propagator-b3": "1.8.0",
-        "@opentelemetry/propagator-jaeger": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0",
+        "@opentelemetry/context-async-hooks": "1.12.0",
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/propagator-b3": "1.12.0",
+        "@opentelemetry/propagator-jaeger": "1.12.0",
+        "@opentelemetry/sdk-trace-base": "1.12.0",
         "semver": "^7.3.5"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.4.0"
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
-      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.12.0.tgz",
+      "integrity": "sha512-hO+bdeGOlJwqowUBoZF5LyP3ORUFOP1G0GRv8N45W/cztXbT2ZEXaAzfokRS9Xc9FWmYrDj32mF6SzH6wuoIyA==",
       "engines": {
         "node": ">=14"
       }
@@ -1141,66 +1524,66 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@splunk/otel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.1.0.tgz",
-      "integrity": "sha512-TBtfakeCuqF6YlL9wdYz0oLXXxVLvpZQv6txQAeQsMCFlhKy170+8aYqoTZ18bRWnbCuJzvpKTedaFppIQq3bw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.1.tgz",
+      "integrity": "sha512-uf2hQm6BiBCTw9SGxs5lHTC/NhUMsJu7P/pMflbKmLDln7ZuxIxEel3Ecw8e6pZILxv7cJ8kFgbF6GbcOsSAFQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@grpc/proto-loader": "^0.7.3",
+        "@grpc/grpc-js": "^1.8.11",
+        "@grpc/proto-loader": "^0.7.6",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.34.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.34.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.34.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.32.0",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.10.0",
-        "@opentelemetry/instrumentation-bunyan": "^0.31.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.32.0",
-        "@opentelemetry/instrumentation-connect": "^0.31.0",
-        "@opentelemetry/instrumentation-dataloader": "^0.3.0",
-        "@opentelemetry/instrumentation-dns": "^0.31.0",
-        "@opentelemetry/instrumentation-express": "^0.32.0",
-        "@opentelemetry/instrumentation-fastify": "^0.31.0",
-        "@opentelemetry/instrumentation-generic-pool": "^0.31.0",
-        "@opentelemetry/instrumentation-graphql": "^0.33.0",
-        "@opentelemetry/instrumentation-grpc": "^0.34.0",
-        "@opentelemetry/instrumentation-hapi": "^0.31.0",
-        "@opentelemetry/instrumentation-http": "^0.34.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.33.0",
-        "@opentelemetry/instrumentation-knex": "^0.31.0",
-        "@opentelemetry/instrumentation-koa": "^0.34.0",
-        "@opentelemetry/instrumentation-memcached": "^0.31.0",
-        "@opentelemetry/instrumentation-mongodb": "^0.33.0",
-        "@opentelemetry/instrumentation-mysql": "^0.32.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.33.0",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.32.0",
-        "@opentelemetry/instrumentation-net": "^0.31.0",
-        "@opentelemetry/instrumentation-pg": "^0.33.0",
-        "@opentelemetry/instrumentation-pino": "^0.33.0",
-        "@opentelemetry/instrumentation-redis": "^0.34.0",
-        "@opentelemetry/instrumentation-redis-4": "^0.34.0",
-        "@opentelemetry/instrumentation-restify": "^0.31.0",
-        "@opentelemetry/instrumentation-router": "^0.32.0",
-        "@opentelemetry/instrumentation-tedious": "^0.5.0",
-        "@opentelemetry/instrumentation-winston": "^0.31.0",
-        "@opentelemetry/propagator-b3": "^1.8.0",
-        "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-metrics": "^1.8.0",
-        "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.8.0",
+        "@opentelemetry/context-async-hooks": "^1.10.1",
+        "@opentelemetry/core": "^1.10.1",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.36.1",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.36.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.36.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.36.1",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation-amqplib": "^0.32.2",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.34.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.31.1",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.32.1",
+        "@opentelemetry/instrumentation-connect": "^0.31.1",
+        "@opentelemetry/instrumentation-dataloader": "^0.4.0",
+        "@opentelemetry/instrumentation-dns": "^0.31.2",
+        "@opentelemetry/instrumentation-express": "^0.32.1",
+        "@opentelemetry/instrumentation-fastify": "^0.31.1",
+        "@opentelemetry/instrumentation-generic-pool": "^0.31.1",
+        "@opentelemetry/instrumentation-graphql": "^0.33.2",
+        "@opentelemetry/instrumentation-grpc": "^0.35.1",
+        "@opentelemetry/instrumentation-hapi": "^0.31.1",
+        "@opentelemetry/instrumentation-http": "^0.35.1",
+        "@opentelemetry/instrumentation-ioredis": "^0.34.0",
+        "@opentelemetry/instrumentation-knex": "^0.31.1",
+        "@opentelemetry/instrumentation-koa": "^0.34.2",
+        "@opentelemetry/instrumentation-memcached": "^0.31.1",
+        "@opentelemetry/instrumentation-mongodb": "^0.34.1",
+        "@opentelemetry/instrumentation-mongoose": "^0.32.1",
+        "@opentelemetry/instrumentation-mysql": "^0.33.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.33.1",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.32.2",
+        "@opentelemetry/instrumentation-net": "^0.31.1",
+        "@opentelemetry/instrumentation-pg": "^0.35.0",
+        "@opentelemetry/instrumentation-pino": "^0.33.1",
+        "@opentelemetry/instrumentation-redis": "^0.34.3",
+        "@opentelemetry/instrumentation-redis-4": "^0.34.3",
+        "@opentelemetry/instrumentation-restify": "^0.32.1",
+        "@opentelemetry/instrumentation-router": "^0.32.1",
+        "@opentelemetry/instrumentation-tedious": "^0.5.1",
+        "@opentelemetry/instrumentation-winston": "^0.31.1",
+        "@opentelemetry/propagator-b3": "^1.10.1",
+        "@opentelemetry/resources": "^1.10.1",
+        "@opentelemetry/sdk-metrics": "^1.10.1",
+        "@opentelemetry/sdk-trace-base": "^1.10.1",
+        "@opentelemetry/sdk-trace-node": "^1.10.1",
+        "@opentelemetry/semantic-conventions": "^1.10.1",
         "nan": "^2.17.0",
-        "node-gyp-build": "^4.5.0",
-        "opentelemetry-instrumentation-elasticsearch": "^0.34.0",
-        "opentelemetry-instrumentation-kafkajs": "^0.34.0",
-        "opentelemetry-instrumentation-mongoose": "^0.34.0",
-        "opentelemetry-instrumentation-sequelize": "^0.34.0",
-        "opentelemetry-instrumentation-typeorm": "^0.34.0",
-        "protobufjs": "^7.1.2",
+        "node-gyp-build": "^4.6.0",
+        "opentelemetry-instrumentation-elasticsearch": "^0.35.0",
+        "opentelemetry-instrumentation-kafkajs": "^0.35.0",
+        "opentelemetry-instrumentation-sequelize": "^0.35.0",
+        "opentelemetry-instrumentation-typeorm": "^0.35.0",
+        "protobufjs": "^7.2.2",
         "semver": "^7.3.8"
       },
       "engines": {
@@ -1218,24 +1601,10 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/amqplib": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.17.tgz",
-      "integrity": "sha512-RImqiLP1swDqWBW8UX9iBXVEOw6MYzNmxdXqfemDfdwtUvdTM/W0s2RlSuMVIGkRhaWvpkC9O/N81VzzQwfAbw==",
-      "dependencies": {
-        "@types/bluebird": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/aws-lambda": {
       "version": "8.10.81",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.81.tgz",
       "integrity": "sha512-C1rFKGVZ8KwqhwBOYlpoybTSRtxu2433ea6JaO3amc6ubEe08yQoFsPa9aU9YqvX7ppeZ25CnCtC4AH9mhtxsQ=="
-    },
-    "node_modules/@types/bluebird": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
-      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -1290,9 +1659,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1300,11 +1669,12 @@
       }
     },
     "node_modules/@types/generic-pool": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.1.11.tgz",
-      "integrity": "sha512-3mcD3ewmaKPbiAZglGj8We4ohlSMfw/xS+bbYUhTv/ALgqrrtJjyL4Ju9IgapXooBCTFEew5LAKQqzZV6/43xg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.8.1.tgz",
+      "integrity": "sha512-eaMAbZS0EfKvaP5PUZ/Cdf5uJBO2t6T3RdvQTKuMqUwGhNpCnPAsKWEMyV+mCeCQG3UiHrtgdzni8X6DmhxRaQ==",
+      "deprecated": "This is a stub types definition. generic-pool provides its own type definitions, so you do not need this installed.",
       "dependencies": {
-        "@types/node": "*"
+        "generic-pool": "*"
       }
     },
     "node_modules/@types/hapi__catbox": {
@@ -1353,10 +1723,11 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
     },
-    "node_modules/@types/ioredis": {
-      "version": "4.26.6",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.6.tgz",
-      "integrity": "sha512-Q9ydXL/5Mot751i7WLCm9OGTj5jlW3XBdkdEW21SkXZ8Y03srbkluFGbM3q8c+vzPW30JOLJ+NsZWHoly0+13A==",
+    "node_modules/@types/ioredis4": {
+      "name": "@types/ioredis",
+      "version": "4.28.10",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.10.tgz",
+      "integrity": "sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1367,9 +1738,9 @@
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "node_modules/@types/koa": {
-      "version": "2.13.4",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.4.tgz",
-      "integrity": "sha512-dfHYMfU+z/vKtQB7NUrthdAEiSvnLebvBjwHtfFmpZmB7em2N3WVQdHgnFq+xvyVgxW5jKDmjWfLD3lw4g4uTw==",
+      "version": "2.13.6",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.6.tgz",
+      "integrity": "sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==",
       "dependencies": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -1429,9 +1800,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
+      "version": "18.16.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
+      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
     },
     "node_modules/@types/pg": {
       "version": "8.6.1",
@@ -1461,18 +1832,10 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
-    "node_modules/@types/redis": {
-      "version": "2.8.31",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.31.tgz",
-      "integrity": "sha512-daWrrTDYaa5iSDFbgzZ9gOOzyp2AJmYK59OlG/2KGBgYWF3lfs8GDKm1c//tik5Uc93hDD36O+qLPvzDolChbA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
+      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
       "dependencies": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -1513,6 +1876,14 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -1538,6 +1909,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1573,6 +1949,14 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1592,10 +1976,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "node_modules/is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -1616,15 +2005,20 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/joi": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
-      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "version": "17.9.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
+      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
+        "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },
@@ -1664,15 +2058,29 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/mysql": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
+      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+      "dependencies": {
+        "bignumber.js": "9.0.0",
+        "readable-stream": "2.3.7",
+        "safe-buffer": "5.1.2",
+        "sqlstring": "2.3.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
       "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -1680,12 +2088,12 @@
       }
     },
     "node_modules/opentelemetry-instrumentation-elasticsearch": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-elasticsearch/-/opentelemetry-instrumentation-elasticsearch-0.34.0.tgz",
-      "integrity": "sha512-AJbxwBB+JPG84VNg/1x9xXBpbrG2LYipM2zAZr3jgqqvXv9CNjPN6EdTfB5bDeO/O3H3igS4zx8fo19LFDi6Cg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-elasticsearch/-/opentelemetry-instrumentation-elasticsearch-0.35.0.tgz",
+      "integrity": "sha512-KszivGSj50g+zSc5nfXxvJUR1hRmRZ+OgmsfH5i8RwVxhQpa35QQ5vrp5P8lrM/H5BSA27JFtEbR7WL3E8K3fg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.8.0"
       },
       "peerDependencies": {
@@ -1693,25 +2101,11 @@
       }
     },
     "node_modules/opentelemetry-instrumentation-kafkajs": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-kafkajs/-/opentelemetry-instrumentation-kafkajs-0.34.0.tgz",
-      "integrity": "sha512-a1k6hTgeaU5j9GAQVdy4dCWI4y6DGcYMgHWtYnBpQTuHuXIzl+X9EZJjCp36ZDTLw+H1B4M7m7NobVmxwlPVUQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-kafkajs/-/opentelemetry-instrumentation-kafkajs-0.35.0.tgz",
+      "integrity": "sha512-mhB37umd+ONX1s64yXScgx7abl2n1Mm6mNXWycR1/+mQqvvkLPHbz3Qa3axsPd7J9EQ0+I405z6lR011HCTGZQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.8.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-mongoose": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-mongoose/-/opentelemetry-instrumentation-mongoose-0.34.0.tgz",
-      "integrity": "sha512-EPVynrhy6Ag8XuNrJKM2ReiQ77yxHAPEZxu6EykBDM8LM+Sgag+ejf6RntpK3LyehqTEzMjImyO7rO9mUmBFwA==",
-      "deprecated": "Deprecated in favor of @opentelemetry/instrumentation-mongoose",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.8.0"
       },
       "peerDependencies": {
@@ -1719,12 +2113,12 @@
       }
     },
     "node_modules/opentelemetry-instrumentation-sequelize": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-sequelize/-/opentelemetry-instrumentation-sequelize-0.34.0.tgz",
-      "integrity": "sha512-aL6wT5mktsjRqbimcetwIpEE9sQsmxMNqZ175qA5uT0g8iifso06Oche5r3yolYG9PuVgocLZr+sSVWqdepZwQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-sequelize/-/opentelemetry-instrumentation-sequelize-0.35.0.tgz",
+      "integrity": "sha512-bYcw98dFTbAGcGzIwNa+09mnW7tRgew0qR9L09oo3X3+L6NtA3C6GxGVGBa9ExxHJeokSl5F5ytSMTYVUG4iBA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.8.0"
       },
       "peerDependencies": {
@@ -1732,12 +2126,12 @@
       }
     },
     "node_modules/opentelemetry-instrumentation-typeorm": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-typeorm/-/opentelemetry-instrumentation-typeorm-0.34.0.tgz",
-      "integrity": "sha512-SHm3KWMKbVlBhlK/7ura04ccYPw+KsYJtC/s2SY32KFu5G2875Tu7o//SVvXya7sVuIMKSy7Y7TccFyNoxAsZQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-typeorm/-/opentelemetry-instrumentation-typeorm-0.35.0.tgz",
+      "integrity": "sha512-7hBE3olNNBy0gGWH+Fx/TuYbPKOC+yAIucG9bUJ/wT1xeD0ZR6CtZZMQjyN4eDLVZ0ay+3BLguWbBJAbtARWSg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.8.0",
         "is-promise": "^4.0.0"
       },
@@ -1759,9 +2153,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
-      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -1813,10 +2207,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
+      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -1837,9 +2236,23 @@
       }
     },
     "node_modules/protobufjs/node_modules/long": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-      "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -1863,11 +2276,11 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -1878,10 +2291,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -1896,6 +2314,22 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+      "integrity": "sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -1933,9 +2367,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -1944,6 +2378,11 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
@@ -2010,18 +2449,18 @@
   },
   "dependencies": {
     "@grpc/grpc-js": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.7.3.tgz",
-      "integrity": "sha512-H9l79u4kJ2PVSxUNA08HMYAnUBLj9v6KjYQ7SQ71hOZcEXhShE/y5iQCesP8+6/Ik/7i2O0a10bPquIcYfufog==",
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
+      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
       "requires": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.3.tgz",
-      "integrity": "sha512-5dAvoZwna2Py3Ef96Ux9jIkp3iZ62TUsV00p3wVBPNX5K178UbNi8Q7gQVqwXT1Yq9RejIGG9G2IPEo93T6RcA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.6.tgz",
+      "integrity": "sha512-QyAXR8Hyh7uMDmveWxDSUcJr9NAWaZ2I6IXgAYvQmfflwouTM+rArE2eEaCtLlRqO81j7pRLCt81IefUei6Zbw==",
       "requires": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
@@ -2109,102 +2548,264 @@
       }
     },
     "@opentelemetry/api": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.3.0.tgz",
-      "integrity": "sha512-YveTnGNsFFixTKJz09Oi4zYkiLT5af3WpZDu4aIUM7xX+2bHAkOJayFTVQd6zB8kkWPpbua4Ha6Ql00grdLlJQ=="
-    },
-    "@opentelemetry/api-metrics": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-metrics/-/api-metrics-0.32.0.tgz",
-      "integrity": "sha512-g1WLhpG8B6iuDyZJFRGsR+JKyZ94m5LEmY2f+duEJ9Xb4XRlLHrZvh6G34OH6GJ8iDHxfHb/sWjJ1ZpkI9yGMQ==",
-      "requires": {
-        "@opentelemetry/api": "^1.0.0"
-      }
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
+      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
     },
     "@opentelemetry/context-async-hooks": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.8.0.tgz",
-      "integrity": "sha512-ueLmocbWDi1aoU4IPdOQyt4qz/Dx+NYyU4qoa3d683usbnkDLUXYXJFfKIMPFV2BbrI5qtnpTtzErCKewoM8aw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.12.0.tgz",
+      "integrity": "sha512-PmwAanPNWCyS9JYFzhzVzHgviLhc0UHjOwdth+hp3HgQQ9XZZNE635P8JhAUHZmbghW9/qQFafRWOS4VN9VVnQ==",
       "requires": {}
     },
     "@opentelemetry/core": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.8.0.tgz",
-      "integrity": "sha512-6SDjwBML4Am0AQmy7z1j6HGrWDgeK8awBRUvl1PGw6HayViMk4QpnUXvv4HTHisecgVBy43NE/cstWprm8tIfw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-4DWYNb3dLs2mSCGl65jY3aEgbvPWSHVQV/dmDWiYeWUrMakZQFcymqZOSUNZO0uDrEJoxMu8O5tZktX6UKFwag==",
       "requires": {
-        "@opentelemetry/semantic-conventions": "1.8.0"
+        "@opentelemetry/semantic-conventions": "1.12.0"
       }
     },
     "@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.34.0.tgz",
-      "integrity": "sha512-9INc1TBJ7OwpMsImqUjpPEvQeRyyU9tEiFQIYQ53kKQK7V8MqB5koyDeb5/qBSbNu4ZxSpukAOLPgBOEMDK6Qw==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.36.1.tgz",
+      "integrity": "sha512-yQPHny0Y3HIE1BSqbN82MoqqbbJeLINjL7Qf3kJwv1zt5YLUhYbn3FkqHQWS0YWpAvdjK0/OcN40SjEbVz2HRA==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-metrics": "1.10.1"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
+          "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/resources": "1.10.1",
+            "lodash.merge": "4.6.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
+        }
       }
     },
     "@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.34.0.tgz",
-      "integrity": "sha512-ToRJA4frErHGiKKnPCI3+cvdyK8rksRI+mV6xZ6Yt7HiIrArY9eDX7QaCEZcTLbQIib09LTlCX87TKEL3TToWQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.36.1.tgz",
+      "integrity": "sha512-JcpEBwtBpNhVvmCLH3zjTPDcOld2AeI5rNglv2JrB16QCxQ5pwsOgzw7mPe/UR4u/53Ij7LIjFTOCeyVto/6aA==",
       "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-metrics": "1.10.1"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
+          "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/resources": "1.10.1",
+            "lodash.merge": "4.6.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
+        }
       }
     },
     "@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.34.0.tgz",
-      "integrity": "sha512-l9748EtVH+wl1MWFptiRdieS9OkZgGkG4jQRDj+BGIxKJifIiVu6E2o6y+31fkxVzpLAtcxjAG/far0HHpPeZg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.36.1.tgz",
+      "integrity": "sha512-dKJRKvIiyupuZJOVCzW9wNfsK6RxkELnzCSJHzFoIwhGRXSYpbWyYrfHj4ZJZWYZiQSJ7+I8BFUa4aSkBgnO0w==",
       "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.34.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-metrics": "1.10.1"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
+          "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/resources": "1.10.1",
+            "lodash.merge": "4.6.2"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
+        }
       }
     },
     "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.34.0.tgz",
-      "integrity": "sha512-x1V0daRLS6k0dhBPNNLMOP+OSrh8M60Xs9/YkuZS0+/zdbcIjNvPzo/8+dK3zOJx+j1KF0oBX9zxK0SX3PSnZw==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.36.1.tgz",
+      "integrity": "sha512-U2HdWvQho2VkeSAcAhkZ2wjfUb/1SKQixo5x6LNBF17ES4QYuh5+BagYxfN5FP4dbLnjZpTtFk5lj+97lfNLEw==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-trace-base": "1.10.1"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
+          "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/resources": "1.10.1",
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
+        }
       }
     },
     "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.34.0.tgz",
-      "integrity": "sha512-Ump/OyKxq1b4I01aBWSHJw8PCquZAHZh6ykplcmFBs9BZ8DIM7Jl3+zqrS8Vb7YcZ7DZTYORl8Xv/JQoQ+cFlw==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.36.1.tgz",
+      "integrity": "sha512-pNfrto7amygyyhmL4Kf96wuepROEecBYXSrtoXIVb1aUhUqjWLsA3/6DR3unB5EfSRA1Oq1Z9bqHfNuKqGfPNw==",
       "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.34.0",
-        "@opentelemetry/otlp-transformer": "0.34.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
+        "@opentelemetry/otlp-transformer": "0.36.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-trace-base": "1.10.1"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
+          "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/resources": "1.10.1",
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
+        }
       }
     },
     "@opentelemetry/instrumentation": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
-      "integrity": "sha512-VET/bOh4StOQV4vf1sAvn2JD67BhW2vPZ/ynl2gHXyafme2yB8Hs9+tr1TLzFwNGo7jwMFviFQkZjCYxMuK0AA==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.35.1.tgz",
+      "integrity": "sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==",
       "requires": {
         "require-in-the-middle": "^5.0.3",
         "semver": "^7.3.2",
@@ -2212,431 +2813,521 @@
       }
     },
     "@opentelemetry/instrumentation-amqplib": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.32.0.tgz",
-      "integrity": "sha512-/JkDnNNXHBrmesXS826E2z8c/EZoClO4S8ckQzbqdLd+m+n4u9Q9q/9ZV7WWlSAd7BSt3GJNbcjwdxeA7FobKw==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.32.2.tgz",
+      "integrity": "sha512-NSXvRKtJhBqkKQltmOicg0ChyAA5VfrKPa9WSrFDXvlw8Pjs9UiQQTEYbiBT3V5LSjJXH6CpNnQp6v2bqEldow==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/amqplib": "^0.5.17"
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.34.0.tgz",
-      "integrity": "sha512-y/Tn+sFTssJaEb9cJOU3BTxR7ZrVg+6v0cgCO46SIPahhNrDq1kbQ2fYIdG/EVfwbfJyn80bfOQvfE3hNflmeA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.35.0.tgz",
+      "integrity": "sha512-x6nd1DEf/MYU57AMphwyxQLSPSNit6lnJAMNz9eQmQ0TdzGaWUsWUz2OgoZXzjF2D8hbaJHYaDvl1IUOk7cNVg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.32.0",
-        "@opentelemetry/propagator-aws-xray": "^1.1.1",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/propagator-aws-xray": "^1.2.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/aws-lambda": "8.10.81"
-      },
-      "dependencies": {
-        "@opentelemetry/instrumentation": {
-          "version": "0.32.0",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.32.0.tgz",
-          "integrity": "sha512-y6ADjHpkUz/v1nkyyYjsQa/zorhX+0qVGpFvXMcbjU4sHnBnC02c6wcc93sIgZfiQClIWo45TGku1KQxJ5UUbQ==",
-          "requires": {
-            "@opentelemetry/api-metrics": "0.32.0",
-            "require-in-the-middle": "^5.0.3",
-            "semver": "^7.3.2",
-            "shimmer": "^1.2.1"
-          }
-        }
       }
     },
     "@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.10.0.tgz",
-      "integrity": "sha512-8LJfZjoca9Dn+U19mPGjtKGstUrCj5/cRithJCJxrab24Cyry4DnNqltTrXUGIE5Y6XNxX4VXQHiJC/EYyl/CQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.34.0.tgz",
+      "integrity": "sha512-DT7Z08MVNOk/kyvztV1l4s1YMjW4qTbw852EhKkgpyYeKkxfGwdHqvv6+7MzOboJPXFQv/ADn1zcPtD8Lqia/Q==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/propagation-utils": "^0.29.1",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/propagation-utils": "^0.29.2",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-bunyan": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.31.0.tgz",
-      "integrity": "sha512-yehA39p7olnrfBp4VDmOrK/vvMIvmT/8euimRRpQNa/bAPE7vQnbHokfOxsIXIKYqJdhEc9Rxc5pJ7StTrS7wA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.31.1.tgz",
+      "integrity": "sha512-y81y0L50ocziES+jVcsCM684R+1p3M64bfGwVumZI/cH3LNSlnvOd4xgQom4Ug+UzcYcP9RxjFURDQAvh8tnDw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@types/bunyan": "1.8.7"
       }
     },
     "@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.32.0.tgz",
-      "integrity": "sha512-5b68tqZDCRBFp8oQf7vN9RJY+UAfQyAxsrGiJBgGGK159nOIoHHBLjfM02A4rkmkPdJUNz3G02jkFbHFUN/vnw==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.32.1.tgz",
+      "integrity": "sha512-28tbhM8I7Yp7PfSRnykxMFHKDsJC5efwOOoI/CehxIITSLOLrenmCEeNhSUfVUHzMIiqFiZXW/F0wurbAy38pg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-connect": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.31.0.tgz",
-      "integrity": "sha512-7vzK3KQWjxY5yeTy+uqgclSxcS8qM8fnc2yO67EouHt6YNciJbL0pPKw1tGG6Yem/q5vr4qmFTFuYqjnD9Jq1Q==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.31.1.tgz",
+      "integrity": "sha512-72hDzkUIpq4TFrBi0yooNH/LVQbiGZ3wgL0uVGjvyTfN1ZOfoa5LhverWwtfAcjn1aniVU4xEL6aWqGl0A3nDQ==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/connect": "3.4.35"
       }
     },
     "@opentelemetry/instrumentation-dataloader": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.3.0.tgz",
-      "integrity": "sha512-dV/EXnFrztisi3GXmv9WoweCiw5j02fPZwUKP5VzwqlJFHOy1x4U8qxzhkOYZF4nJFI4X70F2oHXDE1Ah0TRkg==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.4.0.tgz",
+      "integrity": "sha512-t12pWySH7d5Kmo9CZDAPs22d40kzWHyvMFsQGysc7UVtBOXB+Vg7Bzt4j3R4jdal/WkGKRgXL920zhGmziuzxw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0"
+        "@opentelemetry/instrumentation": "^0.35.1"
       }
     },
     "@opentelemetry/instrumentation-dns": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.31.0.tgz",
-      "integrity": "sha512-enaXHCdKPOm8eaRddw3ZA1DDU+7E7fGJs2EuhFi2xlzdyWs6luoycVZaJ2cPvJlNWJLrhBPtyGH6qbxoVi/5FQ==",
+      "version": "0.31.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.31.2.tgz",
+      "integrity": "sha512-BBfMzbJGdEEz/OX2uPq0u9NAX2HL9KZ5x3PqwnJEqnUnRBr8hHJ9xbbY9WKRxZ55cGt8XeQpkj2NbRNkoy4hzQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "semver": "^7.3.2"
       }
     },
     "@opentelemetry/instrumentation-express": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.32.0.tgz",
-      "integrity": "sha512-t2QOKwaZXUXQSJn4G90THpOyxyNBUyK0B059PUQpOqc/uybUo0SI8edfVlYRlcfHadG+S0fnU8QvnldmZ8AJqA==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.32.1.tgz",
+      "integrity": "sha512-MR5ondudJaBG+GscjTWp3dm+mUacWgD9CnFs+EURNzd4EfHpPcxB9ZtFgUfzsp6FMJQZvOsgN5/fHQ4wmkf/fg==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/express": "4.17.13"
       }
     },
     "@opentelemetry/instrumentation-fastify": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.31.0.tgz",
-      "integrity": "sha512-HLKoG3ZY8hgK/xHwTy4CD/ybAc+cRkjal4AEE978vVeV8ArUfiN7SwQu5P97kW03lIpzJ8IDtk8UewpNe8VWyA==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.31.1.tgz",
+      "integrity": "sha512-oROINVKIvkkX3wQidPOYH78ruHwvfVBIi74svkeNaMzZ78xW2Djb/BiA5tXAujhi+fRGl2kwCG580iS9q5G7YA==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.31.0.tgz",
-      "integrity": "sha512-XbF07I0uSfGbPHqjx86LIQWllY0lfIXM0yIpFMxqiW6OY7xRdk6GWcvKmUq/eU+3ZYrLb2nn9EqUpWDMWDnejg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.31.1.tgz",
+      "integrity": "sha512-FvoQKVpafcXvsJvIQU3QOFx/KBwbCblIGW83JWwoz2ymMu1coSJTveqN7cNVqEMR3BZ0eN4Ljgmq3AvimWXiTg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/generic-pool": "^3.1.9"
       }
     },
     "@opentelemetry/instrumentation-graphql": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.0.tgz",
-      "integrity": "sha512-d3Qv847LI5JLJF3iR9+86V7K/+nUqVkNu2XJ1L1/4Ze5sih1R+722tx7IrS7UEDkkoNI0E0m74Yg9pJ0kwXMTQ==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.2.tgz",
+      "integrity": "sha512-LDtPV01e8CHeCWS1Y0FL/katkdlsgvYUaPkZBL72k8F3Rm/rEYCBlswUwBJaBoRLxBY7jlwEm3fiGcTxsFyvSg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0"
+        "@opentelemetry/instrumentation": "^0.35.1"
       }
     },
     "@opentelemetry/instrumentation-grpc": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.34.0.tgz",
-      "integrity": "sha512-IqwWq5d3Jiah0eSm1IH6K32rYKe4nnMKkm7qV6ISwWhFFtUPfuOatUKAttmuvipvPCuxiiIS2P/zbmytkwmFVg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.35.1.tgz",
+      "integrity": "sha512-EBmpCD+5QfUXPmupynjwxt3tUG5bgTrGZT12B0/+By9ZMLboDAryHjpiermanbPh5mTOq0q73YzruGQWU9TExg==",
       "requires": {
-        "@opentelemetry/instrumentation": "0.34.0",
-        "@opentelemetry/semantic-conventions": "1.8.0"
+        "@opentelemetry/instrumentation": "0.35.1",
+        "@opentelemetry/semantic-conventions": "1.9.1"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
+          "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg=="
+        }
       }
     },
     "@opentelemetry/instrumentation-hapi": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.31.0.tgz",
-      "integrity": "sha512-+VPnZFRfXeZpF0WuaCym9mPkjQyJa8t0S/qw7v5OWs6w64VLyT7mFLh6dChYoivwx8N0p+TaO/l/Bb+e4y/neg==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.31.1.tgz",
+      "integrity": "sha512-kk/LdhIb/5AC48xHq1LzoV6My7TgEAANxsIXQwLiIUVBgM5yjH3bEb5TjyqbSVNvqsJ1aU5etQICjKbSNh+zlA==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/hapi__hapi": "20.0.9"
       }
     },
     "@opentelemetry/instrumentation-http": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.34.0.tgz",
-      "integrity": "sha512-sZxpYOggRIFwdcdy1wWBGG8fwiuWWK4j3qv/rdqTwcPvrVT4iSCoPNDMZYxOcxSEP1fybq28SK43e+IKwxVElQ==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.35.1.tgz",
+      "integrity": "sha512-tH92LznX5pcxpuTSb6A662IdldlMk8QTtneDN66h4nIT9ch98Gtu68GSSKjMoTR25GzH3opvPC9mX2xJamxMJw==",
       "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/instrumentation": "0.34.0",
-        "@opentelemetry/semantic-conventions": "1.8.0",
+        "@opentelemetry/core": "1.9.1",
+        "@opentelemetry/instrumentation": "0.35.1",
+        "@opentelemetry/semantic-conventions": "1.9.1",
         "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.1.tgz",
+          "integrity": "sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.9.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
+          "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg=="
+        }
       }
     },
     "@opentelemetry/instrumentation-ioredis": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.33.0.tgz",
-      "integrity": "sha512-RhsR3PFdUNiNGnGPVoNpjrsoNWxKrdyAqSOaodE1uoVsJrVBIEKNCD4P82ccTjCuQHsa8ni0/DCt4Cxq7oNG3g==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.34.0.tgz",
+      "integrity": "sha512-2oEOcsqBHGxt4fDV3lM8vxCZNKv2E7ChChSctu4IPem4ixT4vCBm1oEVDU2/6RcS6vnNS6XtbhCchQtKjUMQyA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/redis-common": "^0.35.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/ioredis": "4.26.6"
+        "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
       }
     },
     "@opentelemetry/instrumentation-knex": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.0.tgz",
-      "integrity": "sha512-BqEFTckHDYgD9sPNhdkoL5BHbGevFoPK2XTKBTZah2DR4rD48G8ntsE8K6kt17lA1Q1jgdqe4U690UxGC6/m3g==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.1.tgz",
+      "integrity": "sha512-X9SIdzmyyoknPwUB+/JfcF8VHujQWxXDNMKl3PpxU2PwEaKpXPKtOgdA7do08tSoULMI0xCftFIzBUFnWivPFQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-koa": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.0.tgz",
-      "integrity": "sha512-+ZLABLbe08U6Xg8Eyu0AJCjchk9Kpah8lUEAUhaNdY2M5RdEqlm4LkvlCdmq425KzsrTX0AeWaCfcvGqFr4+lw==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.3.tgz",
+      "integrity": "sha512-WHPl7MMmeFeM1Mg9kgCU64Zdc6MXwXXw9qnJV4Ajl/7zX6/XyGEatDcTMxaJAzVQKXSHR70lKfl8+/W/UP2wrw==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/koa": "2.13.4",
+        "@types/koa": "2.13.6",
         "@types/koa__router": "8.0.7"
       }
     },
     "@opentelemetry/instrumentation-memcached": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.31.0.tgz",
-      "integrity": "sha512-wkoZQ6TyHWuaHTmV/MSIqJzFyEnjWj6hdRftX6eJUv1xalYjrxDZW6gFiByRdlVKupuksIW3/ntvozyLhzbJqQ==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.31.1.tgz",
+      "integrity": "sha512-uDiLLTsXlXLIvwYdl9+1AvxvWZkYrXAIvHwPOi6FthznnDIJtyxk0DgxusUaezhRUS9W1CqO5hFb1+8Hmg5DCQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/memcached": "^2.2.6"
       }
     },
     "@opentelemetry/instrumentation-mongodb": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.33.0.tgz",
-      "integrity": "sha512-bjRF55grOFRn5XQxm1yDL56FD9UVvmIcBDSsgA0dbUr3VOUu3sN7o34t2uDx7EpnfwhMeAvOBO1wbWXdHBzapg==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.34.1.tgz",
+      "integrity": "sha512-zRmotNkUQF6G9KWMEr2K2xZSqlaYKLY4HvV+DGHtOeJ1NbRUFk0V5XBNpB6nc4dXiEJUlGfXRyrQ/yu5TKiUuA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
+      }
+    },
+    "@opentelemetry/instrumentation-mongoose": {
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.32.1.tgz",
+      "integrity": "sha512-ibTM94JpTM6nbfARoql0wLWFOOchCIlDAhSibFNxQ+TImWLZxVQ6NpNnrtbrNoUoPD0xnB/ZlYR7as72Xu4Vyg==",
+      "requires": {
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-mysql": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.32.0.tgz",
-      "integrity": "sha512-9BGbc0wiNokflUKmI3WEOnmCqp9QffcnrIoIs2cjqQekZGAzSmL7tyyL3SoW/qXWOUP8FM+OuEomklujNOZYbg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.33.0.tgz",
+      "integrity": "sha512-dU0phFuwtI81M7HyHbr/N4OllEAWYbQaOtSaJnDPMCxy4f840Np1kPzcTcAqd6zYIMhaO3B1nt7N2cP3ftu2RQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/mysql": "2.15.19"
+        "@types/mysql": "2.15.19",
+        "mysql": "2.18.1"
       }
     },
     "@opentelemetry/instrumentation-mysql2": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.33.0.tgz",
-      "integrity": "sha512-DVWkr/WkALmIdtLoiVp/vgZVOXUCFvnlKOEz+LOQMHOktm0FLhdHRjX7jJhtVtEO7DdZQRnfpUYv8zP37gMawQ==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.33.1.tgz",
+      "integrity": "sha512-ZyGg2KAaQRTctjCUIo+s25Yl4WDAvReF//EA0vKb9nKxMafon1NEbWeO1+qIE6xiXRXFUFn80hnf0N/YLu5gvw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.0.tgz",
-      "integrity": "sha512-kpzegHf1tNqtZhC+BCM/B9n3/e+vBYYYGZK+HUgiL/lHUoUf3Lsj6869eckSgucrScLjDGNBuo5j8JAkdNJ5zw==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.2.tgz",
+      "integrity": "sha512-nUidxCbRnN+QUKArl5f8rE3hkYTsYlHEZRoWMqH9fFsVxOdZ4S6kT/HP55/Pj9+cDZ6XfBbelEOZjpsYeO2dYg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-net": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.31.0.tgz",
-      "integrity": "sha512-uzgI0AMZWYqN/w8oQ3EwSpFKnZ+yMVbzoRczh8pVZgWR8Xw35/h9GfgrOO2Sb9/4nf75bwO83hjRkW4KfsEE7w==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.31.1.tgz",
+      "integrity": "sha512-Gfks0UUi076w7aSTX1Q7KfnmlSqt0vMX0sc6jUWRd/BOQo/r84aS/DU0dP1FuPLyC4Vzpx9pPCnD37MRPhbkKA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-pg": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.33.0.tgz",
-      "integrity": "sha512-RYs4xsGkIKM5cw/3WPRKxjDyLd1DXhwYaNugJlbozDzkToZ1SRzd8I2qAJ2nTTKHtFrWYCqZILPXnRguZNHmnA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.35.0.tgz",
+      "integrity": "sha512-vNcnILF9c+SJVZr0R0xKY9HzbATLwRVbKrrIbkD6Oj4uzfarlA6n2bF3LJAYGMMcDSdxUN+KaTMeW9byLKqqTg==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/core": "^1.8.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/pg": "8.6.1",
         "@types/pg-pool": "2.0.3"
       }
     },
     "@opentelemetry/instrumentation-pino": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.33.0.tgz",
-      "integrity": "sha512-2ZU6ri1/90UpLIZGIeF48BG58mZEtHBUgxYPj08J+HbatHkLg5RQtIy0Q9P9UbAAq+2+Izh2RDm5K1T5OVGkMg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.33.1.tgz",
+      "integrity": "sha512-Rajum1USKFE3khFSg7JRqoI+2BK2BpC2SiB0mjXdQ5s31IxaNuc6qiXdNz6mRzbdzMb/ydsJchlQiSNwB2iVeQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0"
+        "@opentelemetry/instrumentation": "^0.35.1"
       }
     },
     "@opentelemetry/instrumentation-redis": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.34.0.tgz",
-      "integrity": "sha512-fUrU3Ekhxu6bcnurP/rfhZJNxQV9qUP2vQSQSRwPiPZs+s3UKuY19rQEFCST10jF66rQrqB32VwnGqeQyZbHlw==",
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.34.4.tgz",
+      "integrity": "sha512-X1iX75gcQGImLRGZ7s7vbgKy3zIwgZO9fECq7jDnSjBoQ2WxTs8BMN/J2wqEE4SUawxzbHxQqcvAXEy3zA4r0A==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/redis": "2.8.31"
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/redis-common": "^0.35.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-redis-4": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.34.0.tgz",
-      "integrity": "sha512-b3joRK8+aSszaznUoL8vtZrwreN/CJY0VZbmE3HE8IUvOc6W0QRvOl7fDAJ2z56lDT0f7cZSV05gpvslXgZeWg==",
+      "version": "0.34.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.34.3.tgz",
+      "integrity": "sha512-JdHK/retw8rttFkv393P07PEtxhaPLbWXWSJC8Y9kBAoZ+vFEMTM5z+vPQTfgcBQFveyy6v6GEa6H1ozd35z7w==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/redis-common": "^0.35.0",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-restify": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.31.0.tgz",
-      "integrity": "sha512-b0AWFZ9+tm4Iaydt1AquBpsQty+Uv1YQ3C9Jb4/JTknWDWW63tb8FoCcALMPYDulvOgH+PPDvtvZY0Q0Imbstg==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.32.1.tgz",
+      "integrity": "sha512-eko2ESs93LA8G81+qaVsDsCMdvDvvtWJKILBbqJAUeas0WqdLvytcMv/KlXGrHkenTtHA+t1pyTOPw4uyxELsQ==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-router": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.32.0.tgz",
-      "integrity": "sha512-s7RywETzH4FW+8yzPqbBYh5BdtILjM9cjhofucVXDcKY3tNSJA1gGBTCDOK49+ec9zyo1e+nchiYaeS9IW8U/A==",
+      "version": "0.32.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.32.1.tgz",
+      "integrity": "sha512-hLj2+Io3jaLfknaXOLhZc/ITs0St29Kf/LGIpfUA067JKtf9YSXndlfvI731nFf6O0KzKWc9loD/mKvc9W4bWQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0"
       }
     },
     "@opentelemetry/instrumentation-tedious": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.5.0.tgz",
-      "integrity": "sha512-PaaB56cggwg69JPTi3CYR0JnXV+hjBFAnkhKKwIKeaiHew7txOfPZo8S1cEW058jOPFySV+Qg8ZkGApXkvp5zg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.5.1.tgz",
+      "integrity": "sha512-iDDF/ZtxoV6eGzOjVj5qnHJ88RpTg7SbRnrFjPQ4E8HaNEjlnMnig3LjIKESV6GZpPO2DVciqIBWSfs8x34RIw==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/tedious": "^4.0.6"
       }
     },
     "@opentelemetry/instrumentation-winston": {
-      "version": "0.31.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.31.0.tgz",
-      "integrity": "sha512-+19vD2v9wWuUP4Hz0dHcpeT5/5Ke0dtIeZ+zCFXJA4lLLR9QeKMN0ORFlbpAOBwKjjuaBHXnMAwuoMSdOUxCKw==",
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.31.1.tgz",
+      "integrity": "sha512-qPK89Fp5bI6+IGMm2J2+A4kmeRfvRdrfgdwYlXoMZhO4aLL6BL5thdPYkDmIKO4FIzoOmybg62H3lMAExUUAyA==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0"
+        "@opentelemetry/instrumentation": "^0.35.1"
       }
     },
     "@opentelemetry/otlp-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-xVNvQm7oXeQogeI21iTZRnBrBYS0OVekPutEJgb7jQtHg7x2GWuCBQK9sDo84FRWNXBpNOgSYqsf8/+PxIJ2vA==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.36.1.tgz",
+      "integrity": "sha512-fpjPwLafJIjgxY5qx7Ly74AYmRCd9spC6/jCxvEgGheg1YT4+NkfVnrfllxLRgc9wQNhDj7Y0Knp8RcmXLLVfA==",
       "requires": {
-        "@opentelemetry/core": "1.8.0"
+        "@opentelemetry/core": "1.10.1"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
+        }
       }
     },
     "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-8k3CIVjf2+/kmnQNKIR8GtPIfRsQ5ZxBVh3uKof54stVXH/nX5ArceuQaoEfFoFQ8S8wayBZ1QsBwdab65UK0g==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.36.1.tgz",
+      "integrity": "sha512-71TdQ3Z0D2Trq8rc2UMvky7tmIpg8kVPUhdYH3p0tNsTmbx6GDpEBOpjp2/zCFvQ0SZFVfHH2Oj2OZxZiz+FNQ==",
       "requires": {
         "@grpc/grpc-js": "^1.7.1",
         "@grpc/proto-loader": "^0.7.3",
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
+        }
       }
     },
     "@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.34.0.tgz",
-      "integrity": "sha512-qHnwcAafW8OKeM2a1YQNoL9/sgWVE+JxvMgxf2CtYBqsccIakGPoQ43hLCFLAL3I2Af4BNb5t4KnW8lrtnyUjg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.36.1.tgz",
+      "integrity": "sha512-9ErknJ5fS7r2NxEFeca93H+pGWnCjZCUWsz6Stcj5/z2rgsiZGHXLz3fQoUGQz+iXjiXKkks9wxTCRgWOW+Yiw==",
       "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/otlp-exporter-base": "0.34.0",
-        "protobufjs": "7.1.1"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "protobufjs": "^7.1.2"
       },
       "dependencies": {
-        "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
-        },
-        "protobufjs": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.1.tgz",
-          "integrity": "sha512-d0nMQqS/aT3lfV8bKi9Gbg73vPd2LcDdTDOu6RE/M+h9DY8g1EmDzk3ADPccthEWfTBjkR2oxNdx9Gs8YubT+g==",
+        "@opentelemetry/core": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
           "requires": {
-            "@protobufjs/aspromise": "^1.1.2",
-            "@protobufjs/base64": "^1.1.2",
-            "@protobufjs/codegen": "^2.0.4",
-            "@protobufjs/eventemitter": "^1.1.0",
-            "@protobufjs/fetch": "^1.1.0",
-            "@protobufjs/float": "^1.0.2",
-            "@protobufjs/inquire": "^1.1.0",
-            "@protobufjs/path": "^1.1.2",
-            "@protobufjs/pool": "^1.1.0",
-            "@protobufjs/utf8": "^1.1.0",
-            "@types/node": ">=13.7.0",
-            "long": "^5.0.0"
+            "@opentelemetry/semantic-conventions": "1.10.1"
           }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
         }
       }
     },
     "@opentelemetry/otlp-transformer": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.34.0.tgz",
-      "integrity": "sha512-NghPJvn3pVoWBuhWyBe1n/nWIrj1D1EFUH/bIkWEp0CMVWFLux6R+BkRPZQo5klTcj8xFhCZZIZsL/ubkYPryg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.36.1.tgz",
+      "integrity": "sha512-d2MomkVHBHwfsmNz6E60s/sm7gtpSjFwDzkFLm9brVq//VXzEhaEyfYSeTabdUs4BmrzhqTIogHWlcd6cOiL+w==",
       "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/sdk-metrics": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0"
+        "@opentelemetry/core": "1.10.1",
+        "@opentelemetry/resources": "1.10.1",
+        "@opentelemetry/sdk-metrics": "1.10.1",
+        "@opentelemetry/sdk-trace-base": "1.10.1"
+      },
+      "dependencies": {
+        "@opentelemetry/core": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
+          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+          "requires": {
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/resources": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
+          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/sdk-metrics": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
+          "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/resources": "1.10.1",
+            "lodash.merge": "4.6.2"
+          }
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
+          "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+          "requires": {
+            "@opentelemetry/core": "1.10.1",
+            "@opentelemetry/resources": "1.10.1",
+            "@opentelemetry/semantic-conventions": "1.10.1"
+          }
+        },
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
+          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
+        }
       }
     },
     "@opentelemetry/propagation-utils": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.1.tgz",
-      "integrity": "sha512-sSlkke2RrUuWcbhsRUxbwn6G9XtPa1b8zUoudvxxwvs7nCPE2pQRy32JyqT7CbuWf6gQPK/R1u54T79c93oyGQ==",
+      "version": "0.29.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.2.tgz",
+      "integrity": "sha512-ynHFE2BMSZVK1Vq71qVJtdXQAt+pfYAYHHD+ZQYEKnkJN0F2GVMWz75JiHxh7wytt/maIqV9qcWxfjWFK1TUFw==",
       "requires": {}
     },
     "@opentelemetry/propagator-aws-xray": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.1.1.tgz",
-      "integrity": "sha512-RExCA3v2/xZcGN//JaGIs/WXm2bs2z1YhvC07NG6SBF7Vyt5IGrDoHIQXb5raSP7RjYGbaJ7Qg7ND8qkWTXP6A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.2.0.tgz",
+      "integrity": "sha512-KCNFXdv63c+dItes2pUPVd1QDPmfcx3AVwcgE28emSx6tPI71q11zpMTDAWKPU8J9GQAGXMDyGnRGhIgua40aw==",
       "requires": {
         "@opentelemetry/core": "^1.0.0"
       }
     },
     "@opentelemetry/propagator-b3": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.8.0.tgz",
-      "integrity": "sha512-ffP6AVHyISqK1kiUY1MoVKt43Wp3FJXI8NOePqxBrAU7bRDJ13276VbSl4ugCZbZLTPrPhhSmvQh1WqlfUgcAg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.12.0.tgz",
+      "integrity": "sha512-WFcn98075QPc2zE1obhKydJHUehI5/HuLoelPEVwATj+487hjCwjHj9r2fgmQkWpvuNSB7CJaA0ys6qqq1N6lg==",
       "requires": {
-        "@opentelemetry/core": "1.8.0"
+        "@opentelemetry/core": "1.12.0"
       }
     },
     "@opentelemetry/propagator-jaeger": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.8.0.tgz",
-      "integrity": "sha512-v6GA38k2cqeGAh3368prLW5MsuG2/KxpfWI/PxTPjCa9tThDPq0cvhKpk7cEma3y+F6rieMhwmzZhKQL5QVBzQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.12.0.tgz",
+      "integrity": "sha512-ugtWF7GC6X5RIJ0+iMwW2iVAGNs206CAeq8XQ8OkJRg+v0lp4H0/i+gJ4hubTT8NIL5a3IxtIrAENPLIGdLucQ==",
       "requires": {
-        "@opentelemetry/core": "1.8.0"
+        "@opentelemetry/core": "1.12.0"
       }
     },
+    "@opentelemetry/redis-common": {
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.35.0.tgz",
+      "integrity": "sha512-VgA1RN3wsfx1J9rgVOHkMESV9mB/mrRBTr24KNHtBY4jl8goKe/lmV1Qjjs6EUP8F78E/YJhezQCx9EtBOVweg=="
+    },
     "@opentelemetry/resource-detector-aws": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.2.1.tgz",
-      "integrity": "sha512-ryfMZ644kCLMs+PtoUeW8A5ewYEOm0UBnQJAuFnj2MPofA+pTrXEbfJ39kcVlH5qZKJR6xa9GNB1lRIEv2bA7w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.2.2.tgz",
+      "integrity": "sha512-DFnv0z+D+t224wOS+0rsEfvxqKLKFm0DYHDSuam68JKJ7pDbfpyBWhRc4fzDc/J6JT0LtPT4iMJcytQUiGEOwg==",
       "requires": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
@@ -2644,51 +3335,51 @@
       }
     },
     "@opentelemetry/resources": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.8.0.tgz",
-      "integrity": "sha512-KSyMH6Jvss/PFDy16z5qkCK0ERlpyqixb1xwb73wLMvVq+j7i89lobDjw3JkpCcd1Ws0J6jAI4fw28Zufj2ssg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.12.0.tgz",
+      "integrity": "sha512-gunMKXG0hJrR0LXrqh7BVbziA/+iJBL3ZbXCXO64uY+SrExkwoyJkpiq9l5ismkGF/A20mDEV7tGwh+KyPw00Q==",
       "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/semantic-conventions": "1.8.0"
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/semantic-conventions": "1.12.0"
       }
     },
     "@opentelemetry/sdk-metrics": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.8.0.tgz",
-      "integrity": "sha512-+KYb+uj0vHhl8xzJO+oChS4oP1e+/2Wl3SXoHoIdcEjd1TQfDV+lxOm4oqxWq6wykXvI35/JHyejxSoT+qxGmg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.12.0.tgz",
+      "integrity": "sha512-zOy88Jfk88eTxqu+9ypHLs184dGydJocSWtvWMY10QKVVaxhC3SLKa0uxI/zBtD9S+x0LP65wxrTSfSoUNtCOA==",
       "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/resources": "1.12.0",
         "lodash.merge": "4.6.2"
       }
     },
     "@opentelemetry/sdk-trace-base": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
-      "integrity": "sha512-iH41m0UTddnCKJzZx3M85vlhKzRcmT48pUeBbnzsGrq4nIay1oWVHKM5nhB5r8qRDGvd/n7f/YLCXClxwM0tvA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.12.0.tgz",
+      "integrity": "sha512-pfCOB3tNDlYVoWuz4D7Ji+Jmy9MHnATWHVpkERdCEiwUGEZ+4IvNPXUcPc37wJVmMpjGLeaWgPPrie0KIpWf1A==",
       "requires": {
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/resources": "1.8.0",
-        "@opentelemetry/semantic-conventions": "1.8.0"
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/resources": "1.12.0",
+        "@opentelemetry/semantic-conventions": "1.12.0"
       }
     },
     "@opentelemetry/sdk-trace-node": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.8.0.tgz",
-      "integrity": "sha512-6FqhJEgW9Nke5SO4Ul9+5EWOfms/JeLg5LRqILMPMK4UMBWcOtk7jldvGGyfVpraJ16/WPo/R5NSnMwlupN5zQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.12.0.tgz",
+      "integrity": "sha512-PxpDemnNZLLeFNLAu95/K3QubjlaScXVjVQPlwPui65VRxIvxGVysnN7DFfsref+qoh1hI6nlrYSij43vxdm2w==",
       "requires": {
-        "@opentelemetry/context-async-hooks": "1.8.0",
-        "@opentelemetry/core": "1.8.0",
-        "@opentelemetry/propagator-b3": "1.8.0",
-        "@opentelemetry/propagator-jaeger": "1.8.0",
-        "@opentelemetry/sdk-trace-base": "1.8.0",
+        "@opentelemetry/context-async-hooks": "1.12.0",
+        "@opentelemetry/core": "1.12.0",
+        "@opentelemetry/propagator-b3": "1.12.0",
+        "@opentelemetry/propagator-jaeger": "1.12.0",
+        "@opentelemetry/sdk-trace-base": "1.12.0",
         "semver": "^7.3.5"
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
-      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew=="
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.12.0.tgz",
+      "integrity": "sha512-hO+bdeGOlJwqowUBoZF5LyP3ORUFOP1G0GRv8N45W/cztXbT2ZEXaAzfokRS9Xc9FWmYrDj32mF6SzH6wuoIyA=="
     },
     "@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -2763,65 +3454,65 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@splunk/otel": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.1.0.tgz",
-      "integrity": "sha512-TBtfakeCuqF6YlL9wdYz0oLXXxVLvpZQv6txQAeQsMCFlhKy170+8aYqoTZ18bRWnbCuJzvpKTedaFppIQq3bw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.1.tgz",
+      "integrity": "sha512-uf2hQm6BiBCTw9SGxs5lHTC/NhUMsJu7P/pMflbKmLDln7ZuxIxEel3Ecw8e6pZILxv7cJ8kFgbF6GbcOsSAFQ==",
       "requires": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@grpc/proto-loader": "^0.7.3",
+        "@grpc/grpc-js": "^1.8.11",
+        "@grpc/proto-loader": "^0.7.6",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-async-hooks": "^1.8.0",
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.34.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.34.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.34.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.34.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/instrumentation-amqplib": "^0.32.0",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.10.0",
-        "@opentelemetry/instrumentation-bunyan": "^0.31.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.32.0",
-        "@opentelemetry/instrumentation-connect": "^0.31.0",
-        "@opentelemetry/instrumentation-dataloader": "^0.3.0",
-        "@opentelemetry/instrumentation-dns": "^0.31.0",
-        "@opentelemetry/instrumentation-express": "^0.32.0",
-        "@opentelemetry/instrumentation-fastify": "^0.31.0",
-        "@opentelemetry/instrumentation-generic-pool": "^0.31.0",
-        "@opentelemetry/instrumentation-graphql": "^0.33.0",
-        "@opentelemetry/instrumentation-grpc": "^0.34.0",
-        "@opentelemetry/instrumentation-hapi": "^0.31.0",
-        "@opentelemetry/instrumentation-http": "^0.34.0",
-        "@opentelemetry/instrumentation-ioredis": "^0.33.0",
-        "@opentelemetry/instrumentation-knex": "^0.31.0",
-        "@opentelemetry/instrumentation-koa": "^0.34.0",
-        "@opentelemetry/instrumentation-memcached": "^0.31.0",
-        "@opentelemetry/instrumentation-mongodb": "^0.33.0",
-        "@opentelemetry/instrumentation-mysql": "^0.32.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.33.0",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.32.0",
-        "@opentelemetry/instrumentation-net": "^0.31.0",
-        "@opentelemetry/instrumentation-pg": "^0.33.0",
-        "@opentelemetry/instrumentation-pino": "^0.33.0",
-        "@opentelemetry/instrumentation-redis": "^0.34.0",
-        "@opentelemetry/instrumentation-redis-4": "^0.34.0",
-        "@opentelemetry/instrumentation-restify": "^0.31.0",
-        "@opentelemetry/instrumentation-router": "^0.32.0",
-        "@opentelemetry/instrumentation-tedious": "^0.5.0",
-        "@opentelemetry/instrumentation-winston": "^0.31.0",
-        "@opentelemetry/propagator-b3": "^1.8.0",
-        "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/sdk-metrics": "^1.8.0",
-        "@opentelemetry/sdk-trace-base": "^1.8.0",
-        "@opentelemetry/sdk-trace-node": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.8.0",
+        "@opentelemetry/context-async-hooks": "^1.10.1",
+        "@opentelemetry/core": "^1.10.1",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.36.1",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.36.1",
+        "@opentelemetry/exporter-trace-otlp-grpc": "^0.36.1",
+        "@opentelemetry/exporter-trace-otlp-proto": "^0.36.1",
+        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation-amqplib": "^0.32.2",
+        "@opentelemetry/instrumentation-aws-sdk": "^0.34.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.31.1",
+        "@opentelemetry/instrumentation-cassandra-driver": "^0.32.1",
+        "@opentelemetry/instrumentation-connect": "^0.31.1",
+        "@opentelemetry/instrumentation-dataloader": "^0.4.0",
+        "@opentelemetry/instrumentation-dns": "^0.31.2",
+        "@opentelemetry/instrumentation-express": "^0.32.1",
+        "@opentelemetry/instrumentation-fastify": "^0.31.1",
+        "@opentelemetry/instrumentation-generic-pool": "^0.31.1",
+        "@opentelemetry/instrumentation-graphql": "^0.33.2",
+        "@opentelemetry/instrumentation-grpc": "^0.35.1",
+        "@opentelemetry/instrumentation-hapi": "^0.31.1",
+        "@opentelemetry/instrumentation-http": "^0.35.1",
+        "@opentelemetry/instrumentation-ioredis": "^0.34.0",
+        "@opentelemetry/instrumentation-knex": "^0.31.1",
+        "@opentelemetry/instrumentation-koa": "^0.34.2",
+        "@opentelemetry/instrumentation-memcached": "^0.31.1",
+        "@opentelemetry/instrumentation-mongodb": "^0.34.1",
+        "@opentelemetry/instrumentation-mongoose": "^0.32.1",
+        "@opentelemetry/instrumentation-mysql": "^0.33.0",
+        "@opentelemetry/instrumentation-mysql2": "^0.33.1",
+        "@opentelemetry/instrumentation-nestjs-core": "^0.32.2",
+        "@opentelemetry/instrumentation-net": "^0.31.1",
+        "@opentelemetry/instrumentation-pg": "^0.35.0",
+        "@opentelemetry/instrumentation-pino": "^0.33.1",
+        "@opentelemetry/instrumentation-redis": "^0.34.3",
+        "@opentelemetry/instrumentation-redis-4": "^0.34.3",
+        "@opentelemetry/instrumentation-restify": "^0.32.1",
+        "@opentelemetry/instrumentation-router": "^0.32.1",
+        "@opentelemetry/instrumentation-tedious": "^0.5.1",
+        "@opentelemetry/instrumentation-winston": "^0.31.1",
+        "@opentelemetry/propagator-b3": "^1.10.1",
+        "@opentelemetry/resources": "^1.10.1",
+        "@opentelemetry/sdk-metrics": "^1.10.1",
+        "@opentelemetry/sdk-trace-base": "^1.10.1",
+        "@opentelemetry/sdk-trace-node": "^1.10.1",
+        "@opentelemetry/semantic-conventions": "^1.10.1",
         "nan": "^2.17.0",
-        "node-gyp-build": "^4.5.0",
-        "opentelemetry-instrumentation-elasticsearch": "^0.34.0",
-        "opentelemetry-instrumentation-kafkajs": "^0.34.0",
-        "opentelemetry-instrumentation-mongoose": "^0.34.0",
-        "opentelemetry-instrumentation-sequelize": "^0.34.0",
-        "opentelemetry-instrumentation-typeorm": "^0.34.0",
-        "protobufjs": "^7.1.2",
+        "node-gyp-build": "^4.6.0",
+        "opentelemetry-instrumentation-elasticsearch": "^0.35.0",
+        "opentelemetry-instrumentation-kafkajs": "^0.35.0",
+        "opentelemetry-instrumentation-sequelize": "^0.35.0",
+        "opentelemetry-instrumentation-typeorm": "^0.35.0",
+        "protobufjs": "^7.2.2",
         "semver": "^7.3.8"
       }
     },
@@ -2833,24 +3524,10 @@
         "@types/node": "*"
       }
     },
-    "@types/amqplib": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@types/amqplib/-/amqplib-0.5.17.tgz",
-      "integrity": "sha512-RImqiLP1swDqWBW8UX9iBXVEOw6MYzNmxdXqfemDfdwtUvdTM/W0s2RlSuMVIGkRhaWvpkC9O/N81VzzQwfAbw==",
-      "requires": {
-        "@types/bluebird": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/aws-lambda": {
       "version": "8.10.81",
       "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.81.tgz",
       "integrity": "sha512-C1rFKGVZ8KwqhwBOYlpoybTSRtxu2433ea6JaO3amc6ubEe08yQoFsPa9aU9YqvX7ppeZ25CnCtC4AH9mhtxsQ=="
-    },
-    "@types/bluebird": {
-      "version": "3.5.38",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.38.tgz",
-      "integrity": "sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg=="
     },
     "@types/body-parser": {
       "version": "1.19.2",
@@ -2905,9 +3582,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "version": "4.17.33",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
+      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -2915,11 +3592,11 @@
       }
     },
     "@types/generic-pool": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.1.11.tgz",
-      "integrity": "sha512-3mcD3ewmaKPbiAZglGj8We4ohlSMfw/xS+bbYUhTv/ALgqrrtJjyL4Ju9IgapXooBCTFEew5LAKQqzZV6/43xg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.8.1.tgz",
+      "integrity": "sha512-eaMAbZS0EfKvaP5PUZ/Cdf5uJBO2t6T3RdvQTKuMqUwGhNpCnPAsKWEMyV+mCeCQG3UiHrtgdzni8X6DmhxRaQ==",
       "requires": {
-        "@types/node": "*"
+        "generic-pool": "*"
       }
     },
     "@types/hapi__catbox": {
@@ -2968,10 +3645,10 @@
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
       "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
     },
-    "@types/ioredis": {
-      "version": "4.26.6",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.26.6.tgz",
-      "integrity": "sha512-Q9ydXL/5Mot751i7WLCm9OGTj5jlW3XBdkdEW21SkXZ8Y03srbkluFGbM3q8c+vzPW30JOLJ+NsZWHoly0+13A==",
+    "@types/ioredis4": {
+      "version": "npm:@types/ioredis@4.28.10",
+      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.10.tgz",
+      "integrity": "sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -2982,9 +3659,9 @@
       "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
     },
     "@types/koa": {
-      "version": "2.13.4",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.4.tgz",
-      "integrity": "sha512-dfHYMfU+z/vKtQB7NUrthdAEiSvnLebvBjwHtfFmpZmB7em2N3WVQdHgnFq+xvyVgxW5jKDmjWfLD3lw4g4uTw==",
+      "version": "2.13.6",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.6.tgz",
+      "integrity": "sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==",
       "requires": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -3044,9 +3721,9 @@
       }
     },
     "@types/node": {
-      "version": "18.11.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.10.tgz",
-      "integrity": "sha512-juG3RWMBOqcOuXC643OAdSA525V44cVgGV6dUDuiFtss+8Fk5x1hI93Rsld43VeJVIeqlP9I7Fn9/qaVqoEAuQ=="
+      "version": "18.16.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
+      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
     },
     "@types/pg": {
       "version": "8.6.1",
@@ -3076,18 +3753,10 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
-    "@types/redis": {
-      "version": "2.8.31",
-      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.31.tgz",
-      "integrity": "sha512-daWrrTDYaa5iSDFbgzZ9gOOzyp2AJmYK59OlG/2KGBgYWF3lfs8GDKm1c//tik5Uc93hDD36O+qLPvzDolChbA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@types/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
+      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
       "requires": {
         "@types/mime": "*",
         "@types/node": "*"
@@ -3119,6 +3788,11 @@
         "color-convert": "^2.0.1"
       }
     },
+    "bignumber.js": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
+      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -3141,6 +3815,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "debug": {
       "version": "4.3.4",
@@ -3165,6 +3844,11 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3178,10 +3862,15 @@
         "function-bind": "^1.1.1"
       }
     },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "is-core-module": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
-      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
+      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -3196,15 +3885,20 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "joi": {
-      "version": "17.7.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.7.0.tgz",
-      "integrity": "sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==",
+      "version": "17.9.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
+      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
         "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.0",
+        "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
     },
@@ -3241,62 +3935,63 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "mysql": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
+      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
+      "requires": {
+        "bignumber.js": "9.0.0",
+        "readable-stream": "2.3.7",
+        "safe-buffer": "5.1.2",
+        "sqlstring": "2.3.1"
+      }
+    },
     "nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
       "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
     "node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "opentelemetry-instrumentation-elasticsearch": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-elasticsearch/-/opentelemetry-instrumentation-elasticsearch-0.34.0.tgz",
-      "integrity": "sha512-AJbxwBB+JPG84VNg/1x9xXBpbrG2LYipM2zAZr3jgqqvXv9CNjPN6EdTfB5bDeO/O3H3igS4zx8fo19LFDi6Cg==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-elasticsearch/-/opentelemetry-instrumentation-elasticsearch-0.35.0.tgz",
+      "integrity": "sha512-KszivGSj50g+zSc5nfXxvJUR1hRmRZ+OgmsfH5i8RwVxhQpa35QQ5vrp5P8lrM/H5BSA27JFtEbR7WL3E8K3fg==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.8.0"
       }
     },
     "opentelemetry-instrumentation-kafkajs": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-kafkajs/-/opentelemetry-instrumentation-kafkajs-0.34.0.tgz",
-      "integrity": "sha512-a1k6hTgeaU5j9GAQVdy4dCWI4y6DGcYMgHWtYnBpQTuHuXIzl+X9EZJjCp36ZDTLw+H1B4M7m7NobVmxwlPVUQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-kafkajs/-/opentelemetry-instrumentation-kafkajs-0.35.0.tgz",
+      "integrity": "sha512-mhB37umd+ONX1s64yXScgx7abl2n1Mm6mNXWycR1/+mQqvvkLPHbz3Qa3axsPd7J9EQ0+I405z6lR011HCTGZQ==",
       "requires": {
-        "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.8.0"
-      }
-    },
-    "opentelemetry-instrumentation-mongoose": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-mongoose/-/opentelemetry-instrumentation-mongoose-0.34.0.tgz",
-      "integrity": "sha512-EPVynrhy6Ag8XuNrJKM2ReiQ77yxHAPEZxu6EykBDM8LM+Sgag+ejf6RntpK3LyehqTEzMjImyO7rO9mUmBFwA==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.8.0"
       }
     },
     "opentelemetry-instrumentation-sequelize": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-sequelize/-/opentelemetry-instrumentation-sequelize-0.34.0.tgz",
-      "integrity": "sha512-aL6wT5mktsjRqbimcetwIpEE9sQsmxMNqZ175qA5uT0g8iifso06Oche5r3yolYG9PuVgocLZr+sSVWqdepZwQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-sequelize/-/opentelemetry-instrumentation-sequelize-0.35.0.tgz",
+      "integrity": "sha512-bYcw98dFTbAGcGzIwNa+09mnW7tRgew0qR9L09oo3X3+L6NtA3C6GxGVGBa9ExxHJeokSl5F5ytSMTYVUG4iBA==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.8.0"
       }
     },
     "opentelemetry-instrumentation-typeorm": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-typeorm/-/opentelemetry-instrumentation-typeorm-0.34.0.tgz",
-      "integrity": "sha512-SHm3KWMKbVlBhlK/7ura04ccYPw+KsYJtC/s2SY32KFu5G2875Tu7o//SVvXya7sVuIMKSy7Y7TccFyNoxAsZQ==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-typeorm/-/opentelemetry-instrumentation-typeorm-0.35.0.tgz",
+      "integrity": "sha512-7hBE3olNNBy0gGWH+Fx/TuYbPKOC+yAIucG9bUJ/wT1xeD0ZR6CtZZMQjyN4eDLVZ0ay+3BLguWbBJAbtARWSg==",
       "requires": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.34.0",
+        "@opentelemetry/instrumentation": "^0.35.1",
         "@opentelemetry/semantic-conventions": "^1.8.0",
         "is-promise": "^4.0.0"
       }
@@ -3312,9 +4007,9 @@
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
     },
     "pg-protocol": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.5.0.tgz",
-      "integrity": "sha512-muRttij7H8TqRNu/DxrAJQITO4Ac7RmX3Klyr/9mJEOBeIpgnF8f9jAfRz5d3XwQZl5qBjF9gLsUtMPJE0vezQ=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
     },
     "pg-types": {
       "version": "2.2.0",
@@ -3351,10 +4046,15 @@
         "xtend": "^4.0.0"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "protobufjs": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.1.2.tgz",
-      "integrity": "sha512-4ZPTPkXCdel3+L81yw3dG6+Kq3umdWKh7Dc7GW/CpNk4SX3hK58iPCWeCyhVTDrbkNeKrYNZ7EojM5WDaEWTLQ==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
+      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -3371,10 +4071,24 @@
       },
       "dependencies": {
         "long": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.1.tgz",
-          "integrity": "sha512-GKSNGeNAtw8IryjjkhZxuKB3JzlcLTwjtiQCHKvqQet81I93kXslhDQruGI/QsddO83mcDToBVy7GqGS/zYf/A=="
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
         }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "require-directory": {
@@ -3393,19 +4107,24 @@
       }
     },
     "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "requires": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
+      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -3414,6 +4133,19 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
+    "sqlstring": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
+      "integrity": "sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ=="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "string-width": {
       "version": "4.2.3",
@@ -3439,10 +4171,15 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "typescript": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
-      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "wrap-ansi": {
       "version": "7.0.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -22,33 +22,16 @@
     "splunk"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14"
   },
   "devDependencies": {
     "typescript": "4.9"
   },
   "dependencies": {
-    "@opentelemetry/api": "1.3.0",
-    "@opentelemetry/instrumentation": "0.34.0",
-    "@opentelemetry/instrumentation-aws-lambda": "0.34.0",
-    "@opentelemetry/instrumentation-aws-sdk": "0.10.0",
-    "@opentelemetry/instrumentation-dns": "0.31.0",
-    "@opentelemetry/instrumentation-express": "0.32.0",
-    "@opentelemetry/instrumentation-graphql": "0.33.0",
-    "@opentelemetry/instrumentation-grpc": "0.34.0",
-    "@opentelemetry/instrumentation-hapi": "0.31.0",
-    "@opentelemetry/instrumentation-http": "0.34.0",
-    "@opentelemetry/instrumentation-ioredis": "0.33.0",
-    "@opentelemetry/instrumentation-koa": "0.34.0",
-    "@opentelemetry/instrumentation-mongodb": "0.33.0",
-    "@opentelemetry/instrumentation-mysql": "0.32.0",
-    "@opentelemetry/instrumentation-net": "0.31.0",
-    "@opentelemetry/instrumentation-pg": "0.33.0",
-    "@opentelemetry/instrumentation-redis": "0.34.0",
-    "@opentelemetry/resource-detector-aws": "1.2.1",
-    "@opentelemetry/resources": "1.8.0",
-    "@opentelemetry/sdk-trace-node": "1.8.0",
-    "@splunk/otel": "2.1.0",
+    "@opentelemetry/instrumentation-aws-lambda": "0.35.0",
+    "@opentelemetry/resource-detector-aws": "1.2.2",
+    "@opentelemetry/sdk-trace-node": "^1.10.1",
+    "@splunk/otel": "^2.2.1",
     "@types/signalfx": "7.4.1"
   }
 }

--- a/nodejs/src/wrapper.ts
+++ b/nodejs/src/wrapper.ts
@@ -23,21 +23,6 @@ import { awsLambdaDetector } from '@opentelemetry/resource-detector-aws';
 import type { ResponseHook } from '@opentelemetry/instrumentation-aws-lambda';
 
 import { AwsLambdaInstrumentation } from '@opentelemetry/instrumentation-aws-lambda';
-import { DnsInstrumentation } from '@opentelemetry/instrumentation-dns';
-import { ExpressInstrumentation } from '@opentelemetry/instrumentation-express';
-import { GraphQLInstrumentation } from '@opentelemetry/instrumentation-graphql';
-import { GrpcInstrumentation } from '@opentelemetry/instrumentation-grpc';
-import { HapiInstrumentation } from '@opentelemetry/instrumentation-hapi';
-import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
-import { IORedisInstrumentation } from '@opentelemetry/instrumentation-ioredis';
-import { KoaInstrumentation } from '@opentelemetry/instrumentation-koa';
-import { MongoDBInstrumentation } from '@opentelemetry/instrumentation-mongodb';
-import { MySQLInstrumentation } from '@opentelemetry/instrumentation-mysql';
-import { NetInstrumentation } from '@opentelemetry/instrumentation-net';
-import { PgInstrumentation } from '@opentelemetry/instrumentation-pg';
-import { RedisInstrumentation } from '@opentelemetry/instrumentation-redis';
-
-const { AwsInstrumentation } = require('@opentelemetry/instrumentation-aws-sdk');
 
 import { start } from '@splunk/otel';
 
@@ -115,25 +100,9 @@ const responseHook: ResponseHook = (span, data) => {
   };
 
 const instrumentations = [
-  new AwsInstrumentation({
-    suppressInternalInstrumentation: true,
-  }),
   new AwsLambdaInstrumentation({
     responseHook
   }),
-  new DnsInstrumentation(),
-  new ExpressInstrumentation(),
-  new GraphQLInstrumentation(),
-  new GrpcInstrumentation(),
-  new HapiInstrumentation(),
-  new HttpInstrumentation(),
-  new IORedisInstrumentation(),
-  new KoaInstrumentation(),
-  new MongoDBInstrumentation(),
-  new MySQLInstrumentation(),
-  new NetInstrumentation(),
-  new PgInstrumentation(),
-  new RedisInstrumentation(),
 ];
 
 async function initializeProvider() {

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -10,9 +10,8 @@ pushd "$OTEL_PYTHON_DIR"
 cd "$SOURCES_DIR"
 sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.9.1/g' requirements.txt
 sed -i 's/^opentelemetry-exporter-otlp-proto-http.*/opentelemetry-exporter-otlp-proto-http==1.15.0/g' requirements.txt
-# Leaving these in place for future use even though current versions are fresh
-sed -i 's/0.36b0/0.36b0/g' requirements-nodeps.txt
-sed -i 's/0.36b0/0.36b0/g' requirements.txt
+sed -i 's/0.38b0/0.36b0/g' requirements-nodeps.txt
+sed -i 's/0.38b0/0.36b0/g' requirements.txt
 sed -i 's/^docker run --rm/docker run/g'  ../../build.sh
 sed -i 's/opentelemetry-instrument/splunk-py-trace/g'  otel-instrument
 echo "Modified python wrapper requirements:"


### PR DESCRIPTION
- Update to latest upstream `opentelemetry-lambda`, including collector
- Update java: match upstream otel version (1.24.0), various other libs and build tools
- Update github actions
- Update node.js: using `@splunk/otel` 2.2.1
- No changes to python (but some build tweaks to keep working with upstream)
- No changes to ruby (but build pulls in minor gem updates)