### PR TITLE
fix(node): add bundled instrumentations to config

### DIFF
--- a/nodejs/src/wrapper.ts
+++ b/nodejs/src/wrapper.ts
@@ -25,6 +25,7 @@ import type { ResponseHook } from '@opentelemetry/instrumentation-aws-lambda';
 import { AwsLambdaInstrumentation } from '@opentelemetry/instrumentation-aws-lambda';
 
 import { start } from '@splunk/otel';
+import { getInstrumentations } from '@splunk/otel/lib/instrumentations';
 
 
 // configure lambda logging
@@ -103,6 +104,7 @@ const instrumentations = [
   new AwsLambdaInstrumentation({
     responseHook
   }),
+  ...getInstrumentations(),
 ];
 
 async function initializeProvider() {


### PR DESCRIPTION
The `instrumentations` parameter will make the distro use only the instrumentations given, so all the bundled instrumentations won't be used.

Unless there was a size/startup speed reason, I believe other instrumentations should be loaded as well