### PR TITLE
June 2023 Updates to all versions, dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Check all links in *.md files
         id: lychee
-        uses: lycheeverse/lychee-action@v1.7.0
+        uses: lycheeverse/lychee-action@v1.8.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "opentelemetry-lambda"]
 	path = opentelemetry-lambda
 	url = https://github.com/open-telemetry/opentelemetry-lambda.git
+	branch = main

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     // AWS lambda
     // events
-    implementation("com.amazonaws:aws-lambda-java-events:3.11.1")
+    implementation("com.amazonaws:aws-lambda-java-events:3.11.2")
     // lambda logging
     implementation("com.amazonaws:aws-lambda-java-log4j2:1.5.1")
     implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.18.0")

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -8,8 +8,8 @@ description = "Splunk distribution of OpenTelemetry Lambda"
 
 ext {
     versions = [
-            opentelemetry: '1.24.0',
-            opentelemetryalpha: '1.24.0-alpha'
+            opentelemetry: '1.27.0',
+            opentelemetryalpha: '1.27.0-alpha'
     ]
 }
 

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.11.1'
+    id 'com.gradle.enterprise' version '3.13.4'
 }
 
 gradleEnterprise {

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -13,7 +13,7 @@
         "@opentelemetry/instrumentation-aws-lambda": "0.35.0",
         "@opentelemetry/resource-detector-aws": "1.2.2",
         "@opentelemetry/sdk-trace-node": "^1.10.1",
-        "@splunk/otel": "^2.2.1",
+        "@splunk/otel": "^2.2.2",
         "@types/signalfx": "7.4.1"
       },
       "devDependencies": {
@@ -1524,9 +1524,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@splunk/otel": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.1.tgz",
-      "integrity": "sha512-uf2hQm6BiBCTw9SGxs5lHTC/NhUMsJu7P/pMflbKmLDln7ZuxIxEel3Ecw8e6pZILxv7cJ8kFgbF6GbcOsSAFQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.2.tgz",
+      "integrity": "sha512-oITHtnKD592cZqc2C5fjGQbeXbrByksULXMKo48LjJYig8sAPbDOOBihbzNwdYXYakREDGtQxslmZEsYCvxZ3Q==",
       "hasInstallScript": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.8.11",
@@ -3454,9 +3454,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "@splunk/otel": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.1.tgz",
-      "integrity": "sha512-uf2hQm6BiBCTw9SGxs5lHTC/NhUMsJu7P/pMflbKmLDln7ZuxIxEel3Ecw8e6pZILxv7cJ8kFgbF6GbcOsSAFQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.2.tgz",
+      "integrity": "sha512-oITHtnKD592cZqc2C5fjGQbeXbrByksULXMKo48LjJYig8sAPbDOOBihbzNwdYXYakREDGtQxslmZEsYCvxZ3Q==",
       "requires": {
         "@grpc/grpc-js": "^1.8.11",
         "@grpc/proto-loader": "^0.7.6",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -31,7 +31,7 @@
     "@opentelemetry/instrumentation-aws-lambda": "0.35.0",
     "@opentelemetry/resource-detector-aws": "1.2.2",
     "@opentelemetry/sdk-trace-node": "^1.10.1",
-    "@splunk/otel": "^2.2.1",
+    "@splunk/otel": "^2.2.2",
     "@types/signalfx": "7.4.1"
   }
 }

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -8,10 +8,11 @@ echo "Modify dependencies and script for Splunk integration"
 pushd "$OTEL_PYTHON_DIR"
 
 cd "$SOURCES_DIR"
-sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.9.1/g' requirements.txt
-sed -i 's/^opentelemetry-exporter-otlp-proto-http.*/opentelemetry-exporter-otlp-proto-http==1.15.0/g' requirements.txt
-sed -i 's/0.38b0/0.36b0/g' requirements-nodeps.txt
-sed -i 's/0.38b0/0.36b0/g' requirements.txt
+sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.10.0/g' requirements.txt
+sed -i 's/^opentelemetry-exporter-otlp-proto-http.*/opentelemetry-exporter-otlp-proto-http==1.18.0/g' requirements.txt
+# Even if this regex does nothing, leave these lines in to make later updates easier
+sed -i 's/0.39b0/0.39b0/g' requirements-nodeps.txt
+sed -i 's/0.39b0/0.39b0/g' requirements.txt
 sed -i 's/^docker run --rm/docker run/g'  ../../build.sh
 sed -i 's/opentelemetry-instrument/splunk-py-trace/g'  otel-instrument
 echo "Modified python wrapper requirements:"

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -8,7 +8,7 @@ echo "Modify dependencies and script for Splunk integration"
 pushd "$OTEL_PYTHON_DIR"
 
 cd "$SOURCES_DIR"
-sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.10.0/g' requirements.txt
+sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.11.0/g' requirements.txt
 sed -i 's/^opentelemetry-exporter-otlp-proto-http.*/opentelemetry-exporter-otlp-proto-http==1.18.0/g' requirements.txt
 # Even if this regex does nothing, leave these lines in to make later updates easier
 sed -i 's/0.39b0/0.39b0/g' requirements-nodeps.txt

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -23,7 +23,7 @@ echo "Building OTel Lambda python"
 rm -rf build
 ./build.sh
 cd $DISTRO_DIR
-docker cp "$(docker ps --all | grep aws-otel-lambda-python-layer | cut -d' ' -f1 | head -1)":/out/layer.zip .
+docker cp "$(docker ps --all | grep aws-otel-lambda-python-layer | cut -d' ' -f1 | head -1)":/out/opentelemetry-python-layer.zip ./layer.zip
 unzip -qo layer.zip && rm layer.zip
 mv otel-instrument otel-instrument-upstream
 


### PR DESCRIPTION
- Update collector and pull latest upstream otel-lambda
- Latest versions of build/CI tools
- Updated java dependencies, including otel-java 1.27.0
- Update node's `@splunk/otel` to 2.2.2
- Update to splunk-otel-python 1.11.0 which updates upstream otel-python to 1.18.0/0.39b0
- Change any associated build/tooling/etc. to make it all compile/pass tests

Should be reviewed in the context of additional internal lambda-layers changes.
