### PR TITLE
Update splunk-otel-js to 2.2.4

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@splunk/otel-lambda",
   "version": "0.14.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -12,8 +12,8 @@
       "dependencies": {
         "@opentelemetry/instrumentation-aws-lambda": "0.35.0",
         "@opentelemetry/resource-detector-aws": "1.2.2",
-        "@opentelemetry/sdk-trace-node": "^1.10.1",
-        "@splunk/otel": "^2.2.2",
+        "@opentelemetry/sdk-trace-node": "^1.14.0",
+        "@splunk/otel": "^2.2.4",
         "@types/signalfx": "7.4.1"
       },
       "devDependencies": {
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
-      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
+      "version": "1.8.17",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
+      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -36,15 +36,15 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.6.tgz",
-      "integrity": "sha512-QyAXR8Hyh7uMDmveWxDSUcJr9NAWaZ2I6IXgAYvQmfflwouTM+rArE2eEaCtLlRqO81j7pRLCt81IefUei6Zbw==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.7.tgz",
+      "integrity": "sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
         "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
@@ -145,10 +145,24 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.40.0.tgz",
+      "integrity": "sha512-8WRuvGnfnbeR9ifGjLN8kklk2fkd0gBT6aN7NHO9zeYF/6qacAViD3bwAKqGXKnJgl39l1EU41I9diqUjamEEQ==",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.12.0.tgz",
-      "integrity": "sha512-PmwAanPNWCyS9JYFzhzVzHgviLhc0UHjOwdth+hp3HgQQ9XZZNE635P8JhAUHZmbghW9/qQFafRWOS4VN9VVnQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.15.0.tgz",
+      "integrity": "sha512-sfxQOyAyV3WsKswGX0Yx3P+e7t3EtxpF/PC+6e4+rqs88oUfTaP3214iz4GQuuzV9yCG8DRWTZ96J6E/iD0qeA==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
         "node": ">=14"
       },
@@ -157,11 +171,12 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.12.0.tgz",
-      "integrity": "sha512-4DWYNb3dLs2mSCGl65jY3aEgbvPWSHVQV/dmDWiYeWUrMakZQFcymqZOSUNZO0uDrEJoxMu8O5tZktX6UKFwag==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
+      "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.12.0"
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -171,17 +186,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.36.1.tgz",
-      "integrity": "sha512-yQPHny0Y3HIE1BSqbN82MoqqbbJeLINjL7Qf3kJwv1zt5YLUhYbn3FkqHQWS0YWpAvdjK0/OcN40SjEbVz2HRA==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.40.0.tgz",
+      "integrity": "sha512-1kIEi2G4uVrxqZV+9M09Il2XeylAUOpNXg1vpS50R2CgP99u6ICzu+xhENXWucaVya+tRduwrhkVzSagyP7Mtw==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.40.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.40.0",
+        "@opentelemetry/otlp-transformer": "0.40.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-metrics": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -191,11 +206,11 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -205,12 +220,12 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -219,40 +234,24 @@
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
-      "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
-      "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "lodash.merge": "4.6.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.5.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.36.1.tgz",
-      "integrity": "sha512-JcpEBwtBpNhVvmCLH3zjTPDcOld2AeI5rNglv2JrB16QCxQ5pwsOgzw7mPe/UR4u/53Ij7LIjFTOCeyVto/6aA==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.40.0.tgz",
+      "integrity": "sha512-4ferfcHOyYAhy+7Xk/vMWGBI6yafeOxpLWKrRjzNFAGKzD78teOnPTvyaCecPF0nviTF4VuwT2ECgon6Q/bFBQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/otlp-exporter-base": "0.40.0",
+        "@opentelemetry/otlp-transformer": "0.40.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-metrics": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -262,11 +261,11 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -276,12 +275,12 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -290,42 +289,26 @@
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
-      "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
-      "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "lodash.merge": "4.6.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.5.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.36.1.tgz",
-      "integrity": "sha512-dKJRKvIiyupuZJOVCzW9wNfsK6RxkELnzCSJHzFoIwhGRXSYpbWyYrfHj4ZJZWYZiQSJ7+I8BFUa4aSkBgnO0w==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.40.0.tgz",
+      "integrity": "sha512-Xmh+lUEbxrNGgma9ABdHarr6ICxhrPcFP5gJBjMufdknh1tox7H97GZndtYF2ic5v2Kk0fC1c+j9tKFd4JWDPg==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.40.0",
+        "@opentelemetry/otlp-exporter-base": "0.40.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.40.0",
+        "@opentelemetry/otlp-transformer": "0.40.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-metrics": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -335,11 +318,11 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -349,12 +332,12 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -363,41 +346,25 @@
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
-      "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
-      "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "lodash.merge": "4.6.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.5.0"
-      }
-    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.36.1.tgz",
-      "integrity": "sha512-U2HdWvQho2VkeSAcAhkZ2wjfUb/1SKQixo5x6LNBF17ES4QYuh5+BagYxfN5FP4dbLnjZpTtFk5lj+97lfNLEw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.40.0.tgz",
+      "integrity": "sha512-/UW/6s1WBHkFgdwizouUCEGZPt7NE0Y5xpuFuHqQF/KyjcHzTWibXzB/XWOSS81X55FUxrI3Icoeptk7vtxJFQ==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.40.0",
+        "@opentelemetry/otlp-transformer": "0.40.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -407,11 +374,11 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -421,12 +388,12 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -436,13 +403,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
-      "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
+      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -452,24 +419,24 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.36.1.tgz",
-      "integrity": "sha512-pNfrto7amygyyhmL4Kf96wuepROEecBYXSrtoXIVb1aUhUqjWLsA3/6DR3unB5EfSRA1Oq1Z9bqHfNuKqGfPNw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.40.0.tgz",
+      "integrity": "sha512-1bICfJOrBF+Q+4UYjI0X3brZftLmzPEmVV78/fAiMIEM+DpAYYXW4dEPGL9ta8J5hYI3XXZkwnB3bfeyRA58AQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/otlp-exporter-base": "0.40.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.40.0",
+        "@opentelemetry/otlp-transformer": "0.40.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -479,11 +446,11 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -493,12 +460,12 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -508,13 +475,13 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
-      "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
+      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -524,9 +491,9 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
       "engines": {
         "node": ">=14"
       }
@@ -725,9 +692,9 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.33.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.2.tgz",
-      "integrity": "sha512-LDtPV01e8CHeCWS1Y0FL/katkdlsgvYUaPkZBL72k8F3Rm/rEYCBlswUwBJaBoRLxBY7jlwEm3fiGcTxsFyvSg==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.34.0.tgz",
+      "integrity": "sha512-vRlaxApRW2FuWTsUE/0rrfgk7aQiOPQZDLlG5KIMvC+ExCT0bw//09D5GskUKU596CZy4j/n9WBOBc+Wu5zweA==",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.35.1"
       },
@@ -1102,11 +1069,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.36.1.tgz",
-      "integrity": "sha512-fpjPwLafJIjgxY5qx7Ly74AYmRCd9spC6/jCxvEgGheg1YT4+NkfVnrfllxLRgc9wQNhDj7Y0Knp8RcmXLLVfA==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.40.0.tgz",
+      "integrity": "sha512-AUmMUPM1/oYGbOWYRBBQz4Ic/adMYA/mIMnAy+QAEmCzjBIC/fyRReVhJmF2cpkvYh7QOkX3017zl2dgWLHpvQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1"
+        "@opentelemetry/core": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -1116,11 +1083,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -1130,22 +1097,22 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.36.1.tgz",
-      "integrity": "sha512-71TdQ3Z0D2Trq8rc2UMvky7tmIpg8kVPUhdYH3p0tNsTmbx6GDpEBOpjp2/zCFvQ0SZFVfHH2Oj2OZxZiz+FNQ==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.40.0.tgz",
+      "integrity": "sha512-rgfyCofGMpou1OsCF1fNr/2iBzgeZj3rjplEBi0yfX6s3nNcJ6ZfhDvyblKG6dd/UydPSHYAtFAstZwwuucFJA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@grpc/proto-loader": "^0.7.3",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/otlp-exporter-base": "0.40.0",
+        "protobufjs": "^7.2.2"
       },
       "engines": {
         "node": ">=14"
@@ -1155,11 +1122,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -1169,20 +1136,20 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.36.1.tgz",
-      "integrity": "sha512-9ErknJ5fS7r2NxEFeca93H+pGWnCjZCUWsz6Stcj5/z2rgsiZGHXLz3fQoUGQz+iXjiXKkks9wxTCRgWOW+Yiw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.40.0.tgz",
+      "integrity": "sha512-Wc3Nrmi/BBffrRPgf4ic1jrSnvLEd3+vb2sytDDBzRM97Oobx6RI1Y6bDkCN9pI/VRBaaFap8qT9riVec0MIug==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/otlp-exporter-base": "0.40.0",
         "protobufjs": "^7.1.2"
       },
       "engines": {
@@ -1193,11 +1160,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -1207,22 +1174,24 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.36.1.tgz",
-      "integrity": "sha512-d2MomkVHBHwfsmNz6E60s/sm7gtpSjFwDzkFLm9brVq//VXzEhaEyfYSeTabdUs4BmrzhqTIogHWlcd6cOiL+w==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.40.0.tgz",
+      "integrity": "sha512-YrJgVVAsJHibENSbYmC1x+5jAmkAGZ9yrgmHxc6IyqM3D1mryhqBvMRDD31JoavPYelkS7dmrXWM8g7swX0B+g==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
+        "@opentelemetry/api-logs": "0.40.0",
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-logs": "0.40.0",
+        "@opentelemetry/sdk-metrics": "1.14.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -1232,11 +1201,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -1246,12 +1215,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-      "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -1260,30 +1229,14 @@
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
-      "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
-      "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "lodash.merge": "4.6.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.5.0"
-      }
-    },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
-      "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
+      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/semantic-conventions": "1.10.1"
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
       },
       "engines": {
         "node": ">=14"
@@ -1293,17 +1246,17 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-      "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.2.tgz",
-      "integrity": "sha512-ynHFE2BMSZVK1Vq71qVJtdXQAt+pfYAYHHD+ZQYEKnkJN0F2GVMWz75JiHxh7wytt/maIqV9qcWxfjWFK1TUFw==",
+      "version": "0.29.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.5.tgz",
+      "integrity": "sha512-TRVQAZZfXmatJ8ZrjtQadxv+3n1DbQl42aK2/UOeZ0THdz9EqQ2+IBbvPD484c8H7pjUVUwqDOsk+1BOSPwXEw==",
       "engines": {
         "node": ">=14"
       },
@@ -1312,9 +1265,9 @@
       }
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.2.0.tgz",
-      "integrity": "sha512-KCNFXdv63c+dItes2pUPVd1QDPmfcx3AVwcgE28emSx6tPI71q11zpMTDAWKPU8J9GQAGXMDyGnRGhIgua40aw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.2.1.tgz",
+      "integrity": "sha512-xGPBHXwMvrFuRUfyWj6HEUuQX/QSblN3pcGila/wX01/9KYO5TgFvwKOqR9uxLqvS1s/NaF8J1afsieYCGp7Tg==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0"
       },
@@ -1326,11 +1279,12 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.12.0.tgz",
-      "integrity": "sha512-WFcn98075QPc2zE1obhKydJHUehI5/HuLoelPEVwATj+487hjCwjHj9r2fgmQkWpvuNSB7CJaA0ys6qqq1N6lg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.15.0.tgz",
+      "integrity": "sha512-YafSIITpCmo76VdlJ/GvS5x+uuRWCU5BqCOV9CITi11Tk4aqTxMR3pXlMoPYQWstUUgacQf4dGcdvdS+1rkDWQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.12.0"
+        "@opentelemetry/core": "1.15.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1340,11 +1294,12 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.12.0.tgz",
-      "integrity": "sha512-ugtWF7GC6X5RIJ0+iMwW2iVAGNs206CAeq8XQ8OkJRg+v0lp4H0/i+gJ4hubTT8NIL5a3IxtIrAENPLIGdLucQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.15.0.tgz",
+      "integrity": "sha512-OU6WNxuqjxNZoRcIBCsmvTBktAPuBUj1bh+DI+oYAvzwP2NXLavSDJWjVMGTJQDgZuR7lFijmx9EfwyAO9x37Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.12.0"
+        "@opentelemetry/core": "1.15.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1354,9 +1309,9 @@
       }
     },
     "node_modules/@opentelemetry/redis-common": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.35.0.tgz",
-      "integrity": "sha512-VgA1RN3wsfx1J9rgVOHkMESV9mB/mrRBTr24KNHtBY4jl8goKe/lmV1Qjjs6EUP8F78E/YJhezQCx9EtBOVweg==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.35.1.tgz",
+      "integrity": "sha512-qLXe7h9VzFLx3LaizFiUlpuohCRyvHlDW5b9synE6omHKTZr/n0EHEdmhp3GezBeAqMGI+q499Mht4SmStaSqQ==",
       "engines": {
         "node": ">=14"
       }
@@ -1378,12 +1333,13 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.12.0.tgz",
-      "integrity": "sha512-gunMKXG0hJrR0LXrqh7BVbziA/+iJBL3ZbXCXO64uY+SrExkwoyJkpiq9l5ismkGF/A20mDEV7tGwh+KyPw00Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
+      "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
       "dependencies": {
-        "@opentelemetry/core": "1.12.0",
-        "@opentelemetry/semantic-conventions": "1.12.0"
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1392,13 +1348,66 @@
         "@opentelemetry/api": ">=1.0.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.12.0.tgz",
-      "integrity": "sha512-zOy88Jfk88eTxqu+9ypHLs184dGydJocSWtvWMY10QKVVaxhC3SLKa0uxI/zBtD9S+x0LP65wxrTSfSoUNtCOA==",
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.40.0.tgz",
+      "integrity": "sha512-/JG7DOLo/Y3VR9azPXlXNRGQff3gp7nQbWl5cFD2SmlYqUrzMq1OjbksZLVztDu1+ynbFunseUG11SxhoxvSRg==",
       "dependencies": {
-        "@opentelemetry/core": "1.12.0",
-        "@opentelemetry/resources": "1.12.0",
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api-logs": ">=0.39.1"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.14.0.tgz",
+      "integrity": "sha512-F0JXmLqT4LmsaiaE28fl0qMtc5w0YuMWTHt1hnANTNX8hxW4IKSv9+wrYG7BZd61HEbPm032Re7fXyzzNA6nIw==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
         "lodash.merge": "4.6.2"
       },
       "engines": {
@@ -1408,14 +1417,52 @@
         "@opentelemetry/api": ">=1.3.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.12.0.tgz",
-      "integrity": "sha512-pfCOB3tNDlYVoWuz4D7Ji+Jmy9MHnATWHVpkERdCEiwUGEZ+4IvNPXUcPc37wJVmMpjGLeaWgPPrie0KIpWf1A==",
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
       "dependencies": {
-        "@opentelemetry/core": "1.12.0",
-        "@opentelemetry/resources": "1.12.0",
-        "@opentelemetry/semantic-conventions": "1.12.0"
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.0.tgz",
+      "integrity": "sha512-udt1c9VHipbZwvCPIQR1VLg25Z4AMR/g0X8KmcInbFruGWQ/lptVPkz3yvWAsGSta5yHNQ3uoPwcyCygGnQ6Lg==",
+      "dependencies": {
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/resources": "1.15.0",
+        "@opentelemetry/semantic-conventions": "1.15.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1425,16 +1472,17 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.12.0.tgz",
-      "integrity": "sha512-PxpDemnNZLLeFNLAu95/K3QubjlaScXVjVQPlwPui65VRxIvxGVysnN7DFfsref+qoh1hI6nlrYSij43vxdm2w==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.15.0.tgz",
+      "integrity": "sha512-TKBx9oThZUVKkoGpXhFT/XUgpjq28TWwc6j3JlsL+cJX77DKBnVC+2H+kdVVJHRzyfqDx4LEJJVCwQO3K+cbXA==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.12.0",
-        "@opentelemetry/core": "1.12.0",
-        "@opentelemetry/propagator-b3": "1.12.0",
-        "@opentelemetry/propagator-jaeger": "1.12.0",
-        "@opentelemetry/sdk-trace-base": "1.12.0",
-        "semver": "^7.3.5"
+        "@opentelemetry/context-async-hooks": "1.15.0",
+        "@opentelemetry/core": "1.15.0",
+        "@opentelemetry/propagator-b3": "1.15.0",
+        "@opentelemetry/propagator-jaeger": "1.15.0",
+        "@opentelemetry/sdk-trace-base": "1.15.0",
+        "semver": "^7.5.1",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1444,9 +1492,12 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.12.0.tgz",
-      "integrity": "sha512-hO+bdeGOlJwqowUBoZF5LyP3ORUFOP1G0GRv8N45W/cztXbT2ZEXaAzfokRS9Xc9FWmYrDj32mF6SzH6wuoIyA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
+      "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
         "node": ">=14"
       }
@@ -1524,59 +1575,59 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@splunk/otel": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.2.tgz",
-      "integrity": "sha512-oITHtnKD592cZqc2C5fjGQbeXbrByksULXMKo48LjJYig8sAPbDOOBihbzNwdYXYakREDGtQxslmZEsYCvxZ3Q==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.4.tgz",
+      "integrity": "sha512-9ghXHlX//jGTmmTNHGRpxXmqkOUebaU+1gmjcMC+5gV0Mf3nyDVxCpHNdYjh2Reg7gjUcHSJ6d9AE4R8LxRxLA==",
       "hasInstallScript": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.8.11",
         "@grpc/proto-loader": "^0.7.6",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-async-hooks": "^1.10.1",
-        "@opentelemetry/core": "^1.10.1",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.36.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.36.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.36.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.36.1",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/instrumentation-amqplib": "^0.32.2",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.34.0",
-        "@opentelemetry/instrumentation-bunyan": "^0.31.1",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.32.1",
-        "@opentelemetry/instrumentation-connect": "^0.31.1",
-        "@opentelemetry/instrumentation-dataloader": "^0.4.0",
-        "@opentelemetry/instrumentation-dns": "^0.31.2",
-        "@opentelemetry/instrumentation-express": "^0.32.1",
-        "@opentelemetry/instrumentation-fastify": "^0.31.1",
-        "@opentelemetry/instrumentation-generic-pool": "^0.31.1",
-        "@opentelemetry/instrumentation-graphql": "^0.33.2",
-        "@opentelemetry/instrumentation-grpc": "^0.35.1",
-        "@opentelemetry/instrumentation-hapi": "^0.31.1",
-        "@opentelemetry/instrumentation-http": "^0.35.1",
-        "@opentelemetry/instrumentation-ioredis": "^0.34.0",
-        "@opentelemetry/instrumentation-knex": "^0.31.1",
-        "@opentelemetry/instrumentation-koa": "^0.34.2",
-        "@opentelemetry/instrumentation-memcached": "^0.31.1",
-        "@opentelemetry/instrumentation-mongodb": "^0.34.1",
-        "@opentelemetry/instrumentation-mongoose": "^0.32.1",
-        "@opentelemetry/instrumentation-mysql": "^0.33.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.33.1",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.32.2",
-        "@opentelemetry/instrumentation-net": "^0.31.1",
-        "@opentelemetry/instrumentation-pg": "^0.35.0",
-        "@opentelemetry/instrumentation-pino": "^0.33.1",
-        "@opentelemetry/instrumentation-redis": "^0.34.3",
-        "@opentelemetry/instrumentation-redis-4": "^0.34.3",
-        "@opentelemetry/instrumentation-restify": "^0.32.1",
-        "@opentelemetry/instrumentation-router": "^0.32.1",
-        "@opentelemetry/instrumentation-tedious": "^0.5.1",
-        "@opentelemetry/instrumentation-winston": "^0.31.1",
-        "@opentelemetry/propagator-b3": "^1.10.1",
-        "@opentelemetry/resources": "^1.10.1",
-        "@opentelemetry/sdk-metrics": "^1.10.1",
-        "@opentelemetry/sdk-trace-base": "^1.10.1",
-        "@opentelemetry/sdk-trace-node": "^1.10.1",
-        "@opentelemetry/semantic-conventions": "^1.10.1",
+        "@opentelemetry/context-async-hooks": "1.14.0",
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.40.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.40.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.40.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.40.0",
+        "@opentelemetry/instrumentation": "0.35.1",
+        "@opentelemetry/instrumentation-amqplib": "0.32.2",
+        "@opentelemetry/instrumentation-aws-sdk": "0.34.0",
+        "@opentelemetry/instrumentation-bunyan": "0.31.1",
+        "@opentelemetry/instrumentation-cassandra-driver": "0.32.1",
+        "@opentelemetry/instrumentation-connect": "0.31.1",
+        "@opentelemetry/instrumentation-dataloader": "0.4.0",
+        "@opentelemetry/instrumentation-dns": "0.31.2",
+        "@opentelemetry/instrumentation-express": "0.32.1",
+        "@opentelemetry/instrumentation-fastify": "0.31.1",
+        "@opentelemetry/instrumentation-generic-pool": "0.31.1",
+        "@opentelemetry/instrumentation-graphql": "0.34.0",
+        "@opentelemetry/instrumentation-grpc": "0.35.1",
+        "@opentelemetry/instrumentation-hapi": "0.31.1",
+        "@opentelemetry/instrumentation-http": "0.35.1",
+        "@opentelemetry/instrumentation-ioredis": "0.34.0",
+        "@opentelemetry/instrumentation-knex": "0.31.1",
+        "@opentelemetry/instrumentation-koa": "0.34.3",
+        "@opentelemetry/instrumentation-memcached": "0.31.1",
+        "@opentelemetry/instrumentation-mongodb": "0.34.1",
+        "@opentelemetry/instrumentation-mongoose": "0.32.1",
+        "@opentelemetry/instrumentation-mysql": "0.33.0",
+        "@opentelemetry/instrumentation-mysql2": "0.33.1",
+        "@opentelemetry/instrumentation-nestjs-core": "0.32.2",
+        "@opentelemetry/instrumentation-net": "0.31.1",
+        "@opentelemetry/instrumentation-pg": "0.35.0",
+        "@opentelemetry/instrumentation-pino": "0.33.1",
+        "@opentelemetry/instrumentation-redis": "0.34.4",
+        "@opentelemetry/instrumentation-redis-4": "0.34.3",
+        "@opentelemetry/instrumentation-restify": "0.32.1",
+        "@opentelemetry/instrumentation-router": "0.32.1",
+        "@opentelemetry/instrumentation-tedious": "0.5.1",
+        "@opentelemetry/instrumentation-winston": "0.31.1",
+        "@opentelemetry/propagator-b3": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/sdk-metrics": "1.14.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0",
+        "@opentelemetry/sdk-trace-node": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0",
         "nan": "^2.17.0",
         "node-gyp-build": "^4.6.0",
         "opentelemetry-instrumentation-elasticsearch": "^0.35.0",
@@ -1584,13 +1635,124 @@
         "opentelemetry-instrumentation-sequelize": "^0.35.0",
         "opentelemetry-instrumentation-typeorm": "^0.35.0",
         "protobufjs": "^7.2.2",
-        "semver": "^7.3.8"
+        "semver": "^7.5.3"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/context-async-hooks": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.14.0.tgz",
+      "integrity": "sha512-KfwMzdjxUtQM3uy4ogEdN3pdakFreyZNybKKlvxUM+inF5tAObsGamlmsfmUt6s3mXEC70+DY743+TdG4FMf/Q==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/core": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
+      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/propagator-b3": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.14.0.tgz",
+      "integrity": "sha512-E05zrq0FxbalwJen8XZVfVclKmc5aqvGhMuSfXkbQ3IXC3EE1IcmJXX3T1Fum2JgeUlOt7FM90kaRG0BZ8Bgow==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.14.0.tgz",
+      "integrity": "sha512-B70+npZ9atPdRZjZ/KY5+aiHhK1h/8kqEoPfI6p5Pv0lMgi1aCXwi8w0Cjtm89nV3OhfwNCyuR6dhoFadvO0Ew==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/resources": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
+      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
+      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
+      "dependencies": {
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/resources": "1.14.0",
+        "@opentelemetry/semantic-conventions": "1.14.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.14.0.tgz",
+      "integrity": "sha512-t+batuETp4RBje4F5hdzPTEk/Pg/f5hu+4+x0nkUve+MVqee1yzQrly7KhwcCAlDoMjXB0cwiLBm0NcWbAW5Vw==",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "1.14.0",
+        "@opentelemetry/core": "1.14.0",
+        "@opentelemetry/propagator-b3": "1.14.0",
+        "@opentelemetry/propagator-jaeger": "1.14.0",
+        "@opentelemetry/sdk-trace-base": "1.14.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
+      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/accepts": {
@@ -1659,13 +1821,14 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.33",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
-      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
+      "version": "4.17.35",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
+      "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
-        "@types/range-parser": "*"
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/@types/generic-pool": {
@@ -1782,9 +1945,9 @@
       }
     },
     "node_modules/@types/mime": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/mime-db": {
       "version": "1.43.1",
@@ -1800,9 +1963,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.16.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
-      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
+      "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g=="
     },
     "node_modules/@types/pg": {
       "version": "8.6.1",
@@ -1832,11 +1995,21 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
-      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
+    "node_modules/@types/send": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
+      "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
       "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
+      "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
+      "dependencies": {
+        "@types/http-errors": "*",
         "@types/mime": "*",
         "@types/node": "*"
       }
@@ -1885,13 +2058,16 @@
       }
     },
     "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
+        "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/color-convert": {
@@ -1982,9 +2158,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2213,9 +2389,9 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/protobufjs": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
-      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
+      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -2297,9 +2473,9 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2366,6 +2542,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
+      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
+    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -2422,1808 +2603,29 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dependencies": {
-        "cliui": "^7.0.2",
+        "cliui": "^8.0.1",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.3",
         "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       }
-    }
-  },
-  "dependencies": {
-    "@grpc/grpc-js": {
-      "version": "1.8.14",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.14.tgz",
-      "integrity": "sha512-w84maJ6CKl5aApCMzFll0hxtFNT6or9WwMslobKaqWUEf1K+zhlL43bSQhFreyYWIWR+Z0xnVFC1KtLm4ZpM/A==",
-      "requires": {
-        "@grpc/proto-loader": "^0.7.0",
-        "@types/node": ">=12.12.47"
-      }
-    },
-    "@grpc/proto-loader": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.6.tgz",
-      "integrity": "sha512-QyAXR8Hyh7uMDmveWxDSUcJr9NAWaZ2I6IXgAYvQmfflwouTM+rArE2eEaCtLlRqO81j7pRLCt81IefUei6Zbw==",
-      "requires": {
-        "@types/long": "^4.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
-        "yargs": "^16.2.0"
-      }
-    },
-    "@hapi/b64": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/b64/-/b64-5.0.0.tgz",
-      "integrity": "sha512-ngu0tSEmrezoiIaNGG6rRvKOUkUuDdf4XTPnONHGYfSGRmDqPZX5oJL6HAdKTo1UQHECbdB4OzhWrfgVppjHUw==",
-      "requires": {
-        "@hapi/hoek": "9.x.x"
-      }
-    },
-    "@hapi/boom": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/@hapi/boom/-/boom-9.1.4.tgz",
-      "integrity": "sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==",
-      "requires": {
-        "@hapi/hoek": "9.x.x"
-      }
-    },
-    "@hapi/bourne": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.1.0.tgz",
-      "integrity": "sha512-i1BpaNDVLJdRBEKeJWkVO6tYX6DMFBuwMhSuWqLsY4ufeTKGVuV5rBsUhxPayXqnnWHgXUAmWK16H/ykO5Wj4Q=="
-    },
-    "@hapi/cryptiles": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/cryptiles/-/cryptiles-5.1.0.tgz",
-      "integrity": "sha512-fo9+d1Ba5/FIoMySfMqPBR/7Pa29J2RsiPrl7bkwo5W5o+AN1dAYQRi4SPrPwwVxVGKjgLOEWrsvt1BonJSfLA==",
-      "requires": {
-        "@hapi/boom": "9.x.x"
-      }
-    },
-    "@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "@hapi/iron": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/iron/-/iron-6.0.0.tgz",
-      "integrity": "sha512-zvGvWDufiTGpTJPG1Y/McN8UqWBu0k/xs/7l++HVU535NLHXsHhy54cfEMdW7EjwKfbBfM9Xy25FmTiobb7Hvw==",
-      "requires": {
-        "@hapi/b64": "5.x.x",
-        "@hapi/boom": "9.x.x",
-        "@hapi/bourne": "2.x.x",
-        "@hapi/cryptiles": "5.x.x",
-        "@hapi/hoek": "9.x.x"
-      }
-    },
-    "@hapi/podium": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/podium/-/podium-4.1.3.tgz",
-      "integrity": "sha512-ljsKGQzLkFqnQxE7qeanvgGj4dejnciErYd30dbrYzUOF/FyS/DOF97qcrT3bhoVwCYmxa6PEMhxfCPlnUcD2g==",
-      "requires": {
-        "@hapi/hoek": "9.x.x",
-        "@hapi/teamwork": "5.x.x",
-        "@hapi/validate": "1.x.x"
-      }
-    },
-    "@hapi/teamwork": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/teamwork/-/teamwork-5.1.1.tgz",
-      "integrity": "sha512-1oPx9AE5TIv+V6Ih54RP9lTZBso3rP8j4Xhb6iSVwPXtAM+sDopl5TFMv5Paw73UnpZJ9gjcrTE1BXrWt9eQrg=="
-    },
-    "@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "@hapi/validate": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@hapi/validate/-/validate-1.1.3.tgz",
-      "integrity": "sha512-/XMR0N0wjw0Twzq2pQOzPBZlDzkekGcoCtzO314BpIEsbXdYGthQUbxgkGDf4nhk1+IPDAsXqWjMohRQYO06UA==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0"
-      }
-    },
-    "@opentelemetry/api": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
-      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA=="
-    },
-    "@opentelemetry/context-async-hooks": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.12.0.tgz",
-      "integrity": "sha512-PmwAanPNWCyS9JYFzhzVzHgviLhc0UHjOwdth+hp3HgQQ9XZZNE635P8JhAUHZmbghW9/qQFafRWOS4VN9VVnQ==",
-      "requires": {}
-    },
-    "@opentelemetry/core": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.12.0.tgz",
-      "integrity": "sha512-4DWYNb3dLs2mSCGl65jY3aEgbvPWSHVQV/dmDWiYeWUrMakZQFcymqZOSUNZO0uDrEJoxMu8O5tZktX6UKFwag==",
-      "requires": {
-        "@opentelemetry/semantic-conventions": "1.12.0"
-      }
-    },
-    "@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.36.1.tgz",
-      "integrity": "sha512-yQPHny0Y3HIE1BSqbN82MoqqbbJeLINjL7Qf3kJwv1zt5YLUhYbn3FkqHQWS0YWpAvdjK0/OcN40SjEbVz2HRA==",
-      "requires": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/sdk-metrics": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
-          "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/resources": "1.10.1",
-            "lodash.merge": "4.6.2"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
-        }
-      }
-    },
-    "@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.36.1.tgz",
-      "integrity": "sha512-JcpEBwtBpNhVvmCLH3zjTPDcOld2AeI5rNglv2JrB16QCxQ5pwsOgzw7mPe/UR4u/53Ij7LIjFTOCeyVto/6aA==",
-      "requires": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/sdk-metrics": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
-          "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/resources": "1.10.1",
-            "lodash.merge": "4.6.2"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
-        }
-      }
-    },
-    "@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.36.1.tgz",
-      "integrity": "sha512-dKJRKvIiyupuZJOVCzW9wNfsK6RxkELnzCSJHzFoIwhGRXSYpbWyYrfHj4ZJZWYZiQSJ7+I8BFUa4aSkBgnO0w==",
-      "requires": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.36.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/sdk-metrics": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
-          "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/resources": "1.10.1",
-            "lodash.merge": "4.6.2"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
-        }
-      }
-    },
-    "@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.36.1.tgz",
-      "integrity": "sha512-U2HdWvQho2VkeSAcAhkZ2wjfUb/1SKQixo5x6LNBF17ES4QYuh5+BagYxfN5FP4dbLnjZpTtFk5lj+97lfNLEw==",
-      "requires": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
-          "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/resources": "1.10.1",
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
-        }
-      }
-    },
-    "@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.36.1.tgz",
-      "integrity": "sha512-pNfrto7amygyyhmL4Kf96wuepROEecBYXSrtoXIVb1aUhUqjWLsA3/6DR3unB5EfSRA1Oq1Z9bqHfNuKqGfPNw==",
-      "requires": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-proto-exporter-base": "0.36.1",
-        "@opentelemetry/otlp-transformer": "0.36.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
-          "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/resources": "1.10.1",
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
-        }
-      }
-    },
-    "@opentelemetry/instrumentation": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.35.1.tgz",
-      "integrity": "sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==",
-      "requires": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
-        "shimmer": "^1.2.1"
-      }
-    },
-    "@opentelemetry/instrumentation-amqplib": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.32.2.tgz",
-      "integrity": "sha512-NSXvRKtJhBqkKQltmOicg0ChyAA5VfrKPa9WSrFDXvlw8Pjs9UiQQTEYbiBT3V5LSjJXH6CpNnQp6v2bqEldow==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.35.0.tgz",
-      "integrity": "sha512-x6nd1DEf/MYU57AMphwyxQLSPSNit6lnJAMNz9eQmQ0TdzGaWUsWUz2OgoZXzjF2D8hbaJHYaDvl1IUOk7cNVg==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/propagator-aws-xray": "^1.2.0",
-        "@opentelemetry/resources": "^1.8.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/aws-lambda": "8.10.81"
-      }
-    },
-    "@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.34.0.tgz",
-      "integrity": "sha512-DT7Z08MVNOk/kyvztV1l4s1YMjW4qTbw852EhKkgpyYeKkxfGwdHqvv6+7MzOboJPXFQv/ADn1zcPtD8Lqia/Q==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/propagation-utils": "^0.29.2",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-bunyan": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.31.1.tgz",
-      "integrity": "sha512-y81y0L50ocziES+jVcsCM684R+1p3M64bfGwVumZI/cH3LNSlnvOd4xgQom4Ug+UzcYcP9RxjFURDQAvh8tnDw==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@types/bunyan": "1.8.7"
-      }
-    },
-    "@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.32.1.tgz",
-      "integrity": "sha512-28tbhM8I7Yp7PfSRnykxMFHKDsJC5efwOOoI/CehxIITSLOLrenmCEeNhSUfVUHzMIiqFiZXW/F0wurbAy38pg==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-connect": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.31.1.tgz",
-      "integrity": "sha512-72hDzkUIpq4TFrBi0yooNH/LVQbiGZ3wgL0uVGjvyTfN1ZOfoa5LhverWwtfAcjn1aniVU4xEL6aWqGl0A3nDQ==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/connect": "3.4.35"
-      }
-    },
-    "@opentelemetry/instrumentation-dataloader": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.4.0.tgz",
-      "integrity": "sha512-t12pWySH7d5Kmo9CZDAPs22d40kzWHyvMFsQGysc7UVtBOXB+Vg7Bzt4j3R4jdal/WkGKRgXL920zhGmziuzxw==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1"
-      }
-    },
-    "@opentelemetry/instrumentation-dns": {
-      "version": "0.31.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.31.2.tgz",
-      "integrity": "sha512-BBfMzbJGdEEz/OX2uPq0u9NAX2HL9KZ5x3PqwnJEqnUnRBr8hHJ9xbbY9WKRxZ55cGt8XeQpkj2NbRNkoy4hzQ==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "semver": "^7.3.2"
-      }
-    },
-    "@opentelemetry/instrumentation-express": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.32.1.tgz",
-      "integrity": "sha512-MR5ondudJaBG+GscjTWp3dm+mUacWgD9CnFs+EURNzd4EfHpPcxB9ZtFgUfzsp6FMJQZvOsgN5/fHQ4wmkf/fg==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/express": "4.17.13"
-      }
-    },
-    "@opentelemetry/instrumentation-fastify": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.31.1.tgz",
-      "integrity": "sha512-oROINVKIvkkX3wQidPOYH78ruHwvfVBIi74svkeNaMzZ78xW2Djb/BiA5tXAujhi+fRGl2kwCG580iS9q5G7YA==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.31.1.tgz",
-      "integrity": "sha512-FvoQKVpafcXvsJvIQU3QOFx/KBwbCblIGW83JWwoz2ymMu1coSJTveqN7cNVqEMR3BZ0eN4Ljgmq3AvimWXiTg==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/generic-pool": "^3.1.9"
-      }
-    },
-    "@opentelemetry/instrumentation-graphql": {
-      "version": "0.33.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.33.2.tgz",
-      "integrity": "sha512-LDtPV01e8CHeCWS1Y0FL/katkdlsgvYUaPkZBL72k8F3Rm/rEYCBlswUwBJaBoRLxBY7jlwEm3fiGcTxsFyvSg==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1"
-      }
-    },
-    "@opentelemetry/instrumentation-grpc": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.35.1.tgz",
-      "integrity": "sha512-EBmpCD+5QfUXPmupynjwxt3tUG5bgTrGZT12B0/+By9ZMLboDAryHjpiermanbPh5mTOq0q73YzruGQWU9TExg==",
-      "requires": {
-        "@opentelemetry/instrumentation": "0.35.1",
-        "@opentelemetry/semantic-conventions": "1.9.1"
-      },
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
-          "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg=="
-        }
-      }
-    },
-    "@opentelemetry/instrumentation-hapi": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.31.1.tgz",
-      "integrity": "sha512-kk/LdhIb/5AC48xHq1LzoV6My7TgEAANxsIXQwLiIUVBgM5yjH3bEb5TjyqbSVNvqsJ1aU5etQICjKbSNh+zlA==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/hapi__hapi": "20.0.9"
-      }
-    },
-    "@opentelemetry/instrumentation-http": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.35.1.tgz",
-      "integrity": "sha512-tH92LznX5pcxpuTSb6A662IdldlMk8QTtneDN66h4nIT9ch98Gtu68GSSKjMoTR25GzH3opvPC9mX2xJamxMJw==",
-      "requires": {
-        "@opentelemetry/core": "1.9.1",
-        "@opentelemetry/instrumentation": "0.35.1",
-        "@opentelemetry/semantic-conventions": "1.9.1",
-        "semver": "^7.3.5"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.1.tgz",
-          "integrity": "sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.9.1"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
-          "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg=="
-        }
-      }
-    },
-    "@opentelemetry/instrumentation-ioredis": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.34.0.tgz",
-      "integrity": "sha512-2oEOcsqBHGxt4fDV3lM8vxCZNKv2E7ChChSctu4IPem4ixT4vCBm1oEVDU2/6RcS6vnNS6XtbhCchQtKjUMQyA==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/redis-common": "^0.35.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
-      }
-    },
-    "@opentelemetry/instrumentation-knex": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.1.tgz",
-      "integrity": "sha512-X9SIdzmyyoknPwUB+/JfcF8VHujQWxXDNMKl3PpxU2PwEaKpXPKtOgdA7do08tSoULMI0xCftFIzBUFnWivPFQ==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-koa": {
-      "version": "0.34.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.3.tgz",
-      "integrity": "sha512-WHPl7MMmeFeM1Mg9kgCU64Zdc6MXwXXw9qnJV4Ajl/7zX6/XyGEatDcTMxaJAzVQKXSHR70lKfl8+/W/UP2wrw==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/koa": "2.13.6",
-        "@types/koa__router": "8.0.7"
-      }
-    },
-    "@opentelemetry/instrumentation-memcached": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.31.1.tgz",
-      "integrity": "sha512-uDiLLTsXlXLIvwYdl9+1AvxvWZkYrXAIvHwPOi6FthznnDIJtyxk0DgxusUaezhRUS9W1CqO5hFb1+8Hmg5DCQ==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/memcached": "^2.2.6"
-      }
-    },
-    "@opentelemetry/instrumentation-mongodb": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.34.1.tgz",
-      "integrity": "sha512-zRmotNkUQF6G9KWMEr2K2xZSqlaYKLY4HvV+DGHtOeJ1NbRUFk0V5XBNpB6nc4dXiEJUlGfXRyrQ/yu5TKiUuA==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-mongoose": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.32.1.tgz",
-      "integrity": "sha512-ibTM94JpTM6nbfARoql0wLWFOOchCIlDAhSibFNxQ+TImWLZxVQ6NpNnrtbrNoUoPD0xnB/ZlYR7as72Xu4Vyg==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-mysql": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.33.0.tgz",
-      "integrity": "sha512-dU0phFuwtI81M7HyHbr/N4OllEAWYbQaOtSaJnDPMCxy4f840Np1kPzcTcAqd6zYIMhaO3B1nt7N2cP3ftu2RQ==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/mysql": "2.15.19",
-        "mysql": "2.18.1"
-      }
-    },
-    "@opentelemetry/instrumentation-mysql2": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.33.1.tgz",
-      "integrity": "sha512-ZyGg2KAaQRTctjCUIo+s25Yl4WDAvReF//EA0vKb9nKxMafon1NEbWeO1+qIE6xiXRXFUFn80hnf0N/YLu5gvw==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.2.tgz",
-      "integrity": "sha512-nUidxCbRnN+QUKArl5f8rE3hkYTsYlHEZRoWMqH9fFsVxOdZ4S6kT/HP55/Pj9+cDZ6XfBbelEOZjpsYeO2dYg==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-net": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.31.1.tgz",
-      "integrity": "sha512-Gfks0UUi076w7aSTX1Q7KfnmlSqt0vMX0sc6jUWRd/BOQo/r84aS/DU0dP1FuPLyC4Vzpx9pPCnD37MRPhbkKA==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-pg": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.35.0.tgz",
-      "integrity": "sha512-vNcnILF9c+SJVZr0R0xKY9HzbATLwRVbKrrIbkD6Oj4uzfarlA6n2bF3LJAYGMMcDSdxUN+KaTMeW9byLKqqTg==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/pg": "8.6.1",
-        "@types/pg-pool": "2.0.3"
-      }
-    },
-    "@opentelemetry/instrumentation-pino": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.33.1.tgz",
-      "integrity": "sha512-Rajum1USKFE3khFSg7JRqoI+2BK2BpC2SiB0mjXdQ5s31IxaNuc6qiXdNz6mRzbdzMb/ydsJchlQiSNwB2iVeQ==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1"
-      }
-    },
-    "@opentelemetry/instrumentation-redis": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.34.4.tgz",
-      "integrity": "sha512-X1iX75gcQGImLRGZ7s7vbgKy3zIwgZO9fECq7jDnSjBoQ2WxTs8BMN/J2wqEE4SUawxzbHxQqcvAXEy3zA4r0A==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/redis-common": "^0.35.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-redis-4": {
-      "version": "0.34.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.34.3.tgz",
-      "integrity": "sha512-JdHK/retw8rttFkv393P07PEtxhaPLbWXWSJC8Y9kBAoZ+vFEMTM5z+vPQTfgcBQFveyy6v6GEa6H1ozd35z7w==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/redis-common": "^0.35.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-restify": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.32.1.tgz",
-      "integrity": "sha512-eko2ESs93LA8G81+qaVsDsCMdvDvvtWJKILBbqJAUeas0WqdLvytcMv/KlXGrHkenTtHA+t1pyTOPw4uyxELsQ==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-router": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.32.1.tgz",
-      "integrity": "sha512-hLj2+Io3jaLfknaXOLhZc/ITs0St29Kf/LGIpfUA067JKtf9YSXndlfvI731nFf6O0KzKWc9loD/mKvc9W4bWQ==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/instrumentation-tedious": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.5.1.tgz",
-      "integrity": "sha512-iDDF/ZtxoV6eGzOjVj5qnHJ88RpTg7SbRnrFjPQ4E8HaNEjlnMnig3LjIKESV6GZpPO2DVciqIBWSfs8x34RIw==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/tedious": "^4.0.6"
-      }
-    },
-    "@opentelemetry/instrumentation-winston": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.31.1.tgz",
-      "integrity": "sha512-qPK89Fp5bI6+IGMm2J2+A4kmeRfvRdrfgdwYlXoMZhO4aLL6BL5thdPYkDmIKO4FIzoOmybg62H3lMAExUUAyA==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1"
-      }
-    },
-    "@opentelemetry/otlp-exporter-base": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.36.1.tgz",
-      "integrity": "sha512-fpjPwLafJIjgxY5qx7Ly74AYmRCd9spC6/jCxvEgGheg1YT4+NkfVnrfllxLRgc9wQNhDj7Y0Knp8RcmXLLVfA==",
-      "requires": {
-        "@opentelemetry/core": "1.10.1"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
-        }
-      }
-    },
-    "@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.36.1.tgz",
-      "integrity": "sha512-71TdQ3Z0D2Trq8rc2UMvky7tmIpg8kVPUhdYH3p0tNsTmbx6GDpEBOpjp2/zCFvQ0SZFVfHH2Oj2OZxZiz+FNQ==",
-      "requires": {
-        "@grpc/grpc-js": "^1.7.1",
-        "@grpc/proto-loader": "^0.7.3",
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
-        }
-      }
-    },
-    "@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.36.1.tgz",
-      "integrity": "sha512-9ErknJ5fS7r2NxEFeca93H+pGWnCjZCUWsz6Stcj5/z2rgsiZGHXLz3fQoUGQz+iXjiXKkks9wxTCRgWOW+Yiw==",
-      "requires": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/otlp-exporter-base": "0.36.1",
-        "protobufjs": "^7.1.2"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
-        }
-      }
-    },
-    "@opentelemetry/otlp-transformer": {
-      "version": "0.36.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.36.1.tgz",
-      "integrity": "sha512-d2MomkVHBHwfsmNz6E60s/sm7gtpSjFwDzkFLm9brVq//VXzEhaEyfYSeTabdUs4BmrzhqTIogHWlcd6cOiL+w==",
-      "requires": {
-        "@opentelemetry/core": "1.10.1",
-        "@opentelemetry/resources": "1.10.1",
-        "@opentelemetry/sdk-metrics": "1.10.1",
-        "@opentelemetry/sdk-trace-base": "1.10.1"
-      },
-      "dependencies": {
-        "@opentelemetry/core": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.10.1.tgz",
-          "integrity": "sha512-uBZs9poKMWX7WWHsRfaGHqvrn77D9EU5LwU8Ge3YKD/Su5Gy+T1v476l49nl1UOzEMNo4cISao3nIqQVsABB8g==",
-          "requires": {
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/resources": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.10.1.tgz",
-          "integrity": "sha512-e+wwdyO44jZtsT1aqGiWMFOfN1XuP9Tv4+H0OYP3yQajBtGdsZjdSUn9UNjw46JsW0Mb+RaTxJwsb2uvfHar0g==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/sdk-metrics": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.10.1.tgz",
-          "integrity": "sha512-ARAD4e6lZhLwstwW+1HG2Q3XuYFA/t8vn10KK/mA4em1pZYKFn64c45RJZJcntxWp4wOZRbp9iL1RXsg7zIjow==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/resources": "1.10.1",
-            "lodash.merge": "4.6.2"
-          }
-        },
-        "@opentelemetry/sdk-trace-base": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.10.1.tgz",
-          "integrity": "sha512-jutSP5t22wrPKReJKzI5uKht4mJ4cQdF/mGFJkN+emFFsDXru9CuFv/NfUrD0jEqoaaiqjcZtPSyTzMgu9LXvw==",
-          "requires": {
-            "@opentelemetry/core": "1.10.1",
-            "@opentelemetry/resources": "1.10.1",
-            "@opentelemetry/semantic-conventions": "1.10.1"
-          }
-        },
-        "@opentelemetry/semantic-conventions": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.10.1.tgz",
-          "integrity": "sha512-qiAueuCoN+1YEuHNXnsct9bkbroZBPd7QwQgd56YURG0LBRVHwE/lF6FOprfUvp1n1tu0O6+E3s6x+dmUndXFQ=="
-        }
-      }
-    },
-    "@opentelemetry/propagation-utils": {
-      "version": "0.29.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.2.tgz",
-      "integrity": "sha512-ynHFE2BMSZVK1Vq71qVJtdXQAt+pfYAYHHD+ZQYEKnkJN0F2GVMWz75JiHxh7wytt/maIqV9qcWxfjWFK1TUFw==",
-      "requires": {}
-    },
-    "@opentelemetry/propagator-aws-xray": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.2.0.tgz",
-      "integrity": "sha512-KCNFXdv63c+dItes2pUPVd1QDPmfcx3AVwcgE28emSx6tPI71q11zpMTDAWKPU8J9GQAGXMDyGnRGhIgua40aw==",
-      "requires": {
-        "@opentelemetry/core": "^1.0.0"
-      }
-    },
-    "@opentelemetry/propagator-b3": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.12.0.tgz",
-      "integrity": "sha512-WFcn98075QPc2zE1obhKydJHUehI5/HuLoelPEVwATj+487hjCwjHj9r2fgmQkWpvuNSB7CJaA0ys6qqq1N6lg==",
-      "requires": {
-        "@opentelemetry/core": "1.12.0"
-      }
-    },
-    "@opentelemetry/propagator-jaeger": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.12.0.tgz",
-      "integrity": "sha512-ugtWF7GC6X5RIJ0+iMwW2iVAGNs206CAeq8XQ8OkJRg+v0lp4H0/i+gJ4hubTT8NIL5a3IxtIrAENPLIGdLucQ==",
-      "requires": {
-        "@opentelemetry/core": "1.12.0"
-      }
-    },
-    "@opentelemetry/redis-common": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.35.0.tgz",
-      "integrity": "sha512-VgA1RN3wsfx1J9rgVOHkMESV9mB/mrRBTr24KNHtBY4jl8goKe/lmV1Qjjs6EUP8F78E/YJhezQCx9EtBOVweg=="
-    },
-    "@opentelemetry/resource-detector-aws": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.2.2.tgz",
-      "integrity": "sha512-DFnv0z+D+t224wOS+0rsEfvxqKLKFm0DYHDSuam68JKJ7pDbfpyBWhRc4fzDc/J6JT0LtPT4iMJcytQUiGEOwg==",
-      "requires": {
-        "@opentelemetry/core": "^1.0.0",
-        "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
-      }
-    },
-    "@opentelemetry/resources": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.12.0.tgz",
-      "integrity": "sha512-gunMKXG0hJrR0LXrqh7BVbziA/+iJBL3ZbXCXO64uY+SrExkwoyJkpiq9l5ismkGF/A20mDEV7tGwh+KyPw00Q==",
-      "requires": {
-        "@opentelemetry/core": "1.12.0",
-        "@opentelemetry/semantic-conventions": "1.12.0"
-      }
-    },
-    "@opentelemetry/sdk-metrics": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.12.0.tgz",
-      "integrity": "sha512-zOy88Jfk88eTxqu+9ypHLs184dGydJocSWtvWMY10QKVVaxhC3SLKa0uxI/zBtD9S+x0LP65wxrTSfSoUNtCOA==",
-      "requires": {
-        "@opentelemetry/core": "1.12.0",
-        "@opentelemetry/resources": "1.12.0",
-        "lodash.merge": "4.6.2"
-      }
-    },
-    "@opentelemetry/sdk-trace-base": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.12.0.tgz",
-      "integrity": "sha512-pfCOB3tNDlYVoWuz4D7Ji+Jmy9MHnATWHVpkERdCEiwUGEZ+4IvNPXUcPc37wJVmMpjGLeaWgPPrie0KIpWf1A==",
-      "requires": {
-        "@opentelemetry/core": "1.12.0",
-        "@opentelemetry/resources": "1.12.0",
-        "@opentelemetry/semantic-conventions": "1.12.0"
-      }
-    },
-    "@opentelemetry/sdk-trace-node": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.12.0.tgz",
-      "integrity": "sha512-PxpDemnNZLLeFNLAu95/K3QubjlaScXVjVQPlwPui65VRxIvxGVysnN7DFfsref+qoh1hI6nlrYSij43vxdm2w==",
-      "requires": {
-        "@opentelemetry/context-async-hooks": "1.12.0",
-        "@opentelemetry/core": "1.12.0",
-        "@opentelemetry/propagator-b3": "1.12.0",
-        "@opentelemetry/propagator-jaeger": "1.12.0",
-        "@opentelemetry/sdk-trace-base": "1.12.0",
-        "semver": "^7.3.5"
-      }
-    },
-    "@opentelemetry/semantic-conventions": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.12.0.tgz",
-      "integrity": "sha512-hO+bdeGOlJwqowUBoZF5LyP3ORUFOP1G0GRv8N45W/cztXbT2ZEXaAzfokRS9Xc9FWmYrDj32mF6SzH6wuoIyA=="
-    },
-    "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
-    },
-    "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
-    },
-    "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
-    },
-    "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
-    },
-    "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
-    },
-    "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
-    },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
-    "@sideway/address": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.4.tgz",
-      "integrity": "sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg=="
-    },
-    "@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
-    },
-    "@splunk/otel": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.2.tgz",
-      "integrity": "sha512-oITHtnKD592cZqc2C5fjGQbeXbrByksULXMKo48LjJYig8sAPbDOOBihbzNwdYXYakREDGtQxslmZEsYCvxZ3Q==",
-      "requires": {
-        "@grpc/grpc-js": "^1.8.11",
-        "@grpc/proto-loader": "^0.7.6",
-        "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-async-hooks": "^1.10.1",
-        "@opentelemetry/core": "^1.10.1",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "^0.36.1",
-        "@opentelemetry/exporter-metrics-otlp-proto": "^0.36.1",
-        "@opentelemetry/exporter-trace-otlp-grpc": "^0.36.1",
-        "@opentelemetry/exporter-trace-otlp-proto": "^0.36.1",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/instrumentation-amqplib": "^0.32.2",
-        "@opentelemetry/instrumentation-aws-sdk": "^0.34.0",
-        "@opentelemetry/instrumentation-bunyan": "^0.31.1",
-        "@opentelemetry/instrumentation-cassandra-driver": "^0.32.1",
-        "@opentelemetry/instrumentation-connect": "^0.31.1",
-        "@opentelemetry/instrumentation-dataloader": "^0.4.0",
-        "@opentelemetry/instrumentation-dns": "^0.31.2",
-        "@opentelemetry/instrumentation-express": "^0.32.1",
-        "@opentelemetry/instrumentation-fastify": "^0.31.1",
-        "@opentelemetry/instrumentation-generic-pool": "^0.31.1",
-        "@opentelemetry/instrumentation-graphql": "^0.33.2",
-        "@opentelemetry/instrumentation-grpc": "^0.35.1",
-        "@opentelemetry/instrumentation-hapi": "^0.31.1",
-        "@opentelemetry/instrumentation-http": "^0.35.1",
-        "@opentelemetry/instrumentation-ioredis": "^0.34.0",
-        "@opentelemetry/instrumentation-knex": "^0.31.1",
-        "@opentelemetry/instrumentation-koa": "^0.34.2",
-        "@opentelemetry/instrumentation-memcached": "^0.31.1",
-        "@opentelemetry/instrumentation-mongodb": "^0.34.1",
-        "@opentelemetry/instrumentation-mongoose": "^0.32.1",
-        "@opentelemetry/instrumentation-mysql": "^0.33.0",
-        "@opentelemetry/instrumentation-mysql2": "^0.33.1",
-        "@opentelemetry/instrumentation-nestjs-core": "^0.32.2",
-        "@opentelemetry/instrumentation-net": "^0.31.1",
-        "@opentelemetry/instrumentation-pg": "^0.35.0",
-        "@opentelemetry/instrumentation-pino": "^0.33.1",
-        "@opentelemetry/instrumentation-redis": "^0.34.3",
-        "@opentelemetry/instrumentation-redis-4": "^0.34.3",
-        "@opentelemetry/instrumentation-restify": "^0.32.1",
-        "@opentelemetry/instrumentation-router": "^0.32.1",
-        "@opentelemetry/instrumentation-tedious": "^0.5.1",
-        "@opentelemetry/instrumentation-winston": "^0.31.1",
-        "@opentelemetry/propagator-b3": "^1.10.1",
-        "@opentelemetry/resources": "^1.10.1",
-        "@opentelemetry/sdk-metrics": "^1.10.1",
-        "@opentelemetry/sdk-trace-base": "^1.10.1",
-        "@opentelemetry/sdk-trace-node": "^1.10.1",
-        "@opentelemetry/semantic-conventions": "^1.10.1",
-        "nan": "^2.17.0",
-        "node-gyp-build": "^4.6.0",
-        "opentelemetry-instrumentation-elasticsearch": "^0.35.0",
-        "opentelemetry-instrumentation-kafkajs": "^0.35.0",
-        "opentelemetry-instrumentation-sequelize": "^0.35.0",
-        "opentelemetry-instrumentation-typeorm": "^0.35.0",
-        "protobufjs": "^7.2.2",
-        "semver": "^7.3.8"
-      }
-    },
-    "@types/accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/aws-lambda": {
-      "version": "8.10.81",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.81.tgz",
-      "integrity": "sha512-C1rFKGVZ8KwqhwBOYlpoybTSRtxu2433ea6JaO3amc6ubEe08yQoFsPa9aU9YqvX7ppeZ25CnCtC4AH9mhtxsQ=="
-    },
-    "@types/body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/bunyan": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.7.tgz",
-      "integrity": "sha512-jaNt6xX5poSmXuDAkQrSqx2zkR66OrdRDuVnU8ldvn3k/Ci/7Sf5nooKspQWimDnw337Bzt/yirqSThTjvrHkg==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/connect": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/content-disposition": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
-      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
-    },
-    "@types/cookies": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
-      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
-      "requires": {
-        "@types/connect": "*",
-        "@types/express": "*",
-        "@types/keygrip": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
-      "requires": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.17.33",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.33.tgz",
-      "integrity": "sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==",
-      "requires": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
-      }
-    },
-    "@types/generic-pool": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.8.1.tgz",
-      "integrity": "sha512-eaMAbZS0EfKvaP5PUZ/Cdf5uJBO2t6T3RdvQTKuMqUwGhNpCnPAsKWEMyV+mCeCQG3UiHrtgdzni8X6DmhxRaQ==",
-      "requires": {
-        "generic-pool": "*"
-      }
-    },
-    "@types/hapi__catbox": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.4.tgz",
-      "integrity": "sha512-A6ivRrXD5glmnJna1UAGw87QNZRp/vdFO9U4GS+WhOMWzHnw+oTGkMvg0g6y1930CbeheGOCm7A1qHsqH7AXqg=="
-    },
-    "@types/hapi__hapi": {
-      "version": "20.0.9",
-      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.9.tgz",
-      "integrity": "sha512-fGpKScknCKZityRXdZgpCLGbm41R1ppFgnKHerfZlqOOlCX/jI129S6ghgBqkqCE8m9A0CIu1h7Ch04lD9KOoA==",
-      "requires": {
-        "@hapi/boom": "^9.0.0",
-        "@hapi/iron": "^6.0.0",
-        "@hapi/podium": "^4.1.3",
-        "@types/hapi__catbox": "*",
-        "@types/hapi__mimos": "*",
-        "@types/hapi__shot": "*",
-        "@types/node": "*",
-        "joi": "^17.3.0"
-      }
-    },
-    "@types/hapi__mimos": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@types/hapi__mimos/-/hapi__mimos-4.1.4.tgz",
-      "integrity": "sha512-i9hvJpFYTT/qzB5xKWvDYaSXrIiNqi4ephi+5Lo6+DoQdwqPXQgmVVOZR+s3MBiHoFqsCZCX9TmVWG3HczmTEQ==",
-      "requires": {
-        "@types/mime-db": "*"
-      }
-    },
-    "@types/hapi__shot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.2.tgz",
-      "integrity": "sha512-8wWgLVP1TeGqgzZtCdt+F+k15DWQvLG1Yv6ZzPfb3D5WIo5/S+GGKtJBVo2uNEcqabP5Ifc71QnJTDnTmw1axA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/http-assert": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
-      "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA=="
-    },
-    "@types/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
-    },
-    "@types/ioredis4": {
-      "version": "npm:@types/ioredis@4.28.10",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-4.28.10.tgz",
-      "integrity": "sha512-69LyhUgrXdgcNDv7ogs1qXZomnfOEnSmrmMFqKgt1XMJxmoOSG/u3wYy13yACIfKuMJ8IhKgHafDO3sx19zVQQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/keygrip": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
-    },
-    "@types/koa": {
-      "version": "2.13.6",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.6.tgz",
-      "integrity": "sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==",
-      "requires": {
-        "@types/accepts": "*",
-        "@types/content-disposition": "*",
-        "@types/cookies": "*",
-        "@types/http-assert": "*",
-        "@types/http-errors": "*",
-        "@types/keygrip": "*",
-        "@types/koa-compose": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/koa__router": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.7.tgz",
-      "integrity": "sha512-OB3Ax75nmTP+WR9AgdzA42DI7YmBtiNKN2g1Wxl+d5Dyek9SWt740t+ukwXSmv/jMBCUPyV3YEI93vZHgdP7UQ==",
-      "requires": {
-        "@types/koa": "*"
-      }
-    },
-    "@types/koa-compose": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
-      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
-      "requires": {
-        "@types/koa": "*"
-      }
-    },
-    "@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-    },
-    "@types/memcached": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.7.tgz",
-      "integrity": "sha512-ImJbz1i8pl+OnyhYdIDnHe8jAuM8TOwM/7VsciqhYX3IL0jPPUToAtVxklfcWFGYckahEYZxhd9FS0z3MM1dpA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/mime": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
-      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
-    },
-    "@types/mime-db": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.1.tgz",
-      "integrity": "sha512-kGZJY+R+WnR5Rk+RPHUMERtb2qBRViIHCBdtUrY+NmwuGb8pQdfTqQiCKPrxpdoycl8KWm2DLdkpoSdt479XoQ=="
-    },
-    "@types/mysql": {
-      "version": "2.15.19",
-      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.19.tgz",
-      "integrity": "sha512-wSRg2QZv14CWcZXkgdvHbbV2ACufNy5EgI8mBBxnJIptchv7DBy/h53VMa2jDhyo0C9MO4iowE6z9vF8Ja1DkQ==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/node": {
-      "version": "18.16.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.0.tgz",
-      "integrity": "sha512-BsAaKhB+7X+H4GnSjGhJG9Qi8Tw+inU9nJDwmD5CgOmBLEI6ArdhikpLX7DjbjDRDTbqZzU2LSQNZg8WGPiSZQ=="
-    },
-    "@types/pg": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
-      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
-      "requires": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^2.2.0"
-      }
-    },
-    "@types/pg-pool": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.3.tgz",
-      "integrity": "sha512-fwK5WtG42Yb5RxAwxm3Cc2dJ39FlgcaNiXKvtTLAwtCn642X7dgel+w1+cLWwpSOFImR3YjsZtbkfjxbHtFAeg==",
-      "requires": {
-        "@types/pg": "*"
-      }
-    },
-    "@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
-    },
-    "@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
-    },
-    "@types/serve-static": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.1.tgz",
-      "integrity": "sha512-NUo5XNiAdULrJENtJXZZ3fHtfMolzZwczzBbnAeBbqBwG+LaG6YaJtuwzwGSQZ2wsCrxjEhNNjAkKigy3n8teQ==",
-      "requires": {
-        "@types/mime": "*",
-        "@types/node": "*"
-      }
-    },
-    "@types/signalfx": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@types/signalfx/-/signalfx-7.4.1.tgz",
-      "integrity": "sha512-Beti7SiFPEktPrcwhwkIzyftkbJNomvl54wu3LaSephb1gaf2coroiQ/jRSnp9xnAMsVVAn7l4e59A4Y3OJB9A=="
-    },
-    "@types/tedious": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.9.tgz",
-      "integrity": "sha512-ipwFvfy9b2m0gjHsIX0D6NAAwGCKokzf5zJqUZHUGt+7uWVlBIy6n2eyMgiKQ8ChLFVxic/zwQUhjLYNzbHDRA==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
-    "bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
-    },
-    "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
-    },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "generic-pool": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
-      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g=="
-    },
-    "get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-    },
-    "is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "joi": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
-      "requires": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "module-details-from-path": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-      "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-    },
-    "mysql": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
-      "requires": {
-        "bignumber.js": "9.0.0",
-        "readable-stream": "2.3.7",
-        "safe-buffer": "5.1.2",
-        "sqlstring": "2.3.1"
-      }
-    },
-    "nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
-    },
-    "node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
-    },
-    "opentelemetry-instrumentation-elasticsearch": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-elasticsearch/-/opentelemetry-instrumentation-elasticsearch-0.35.0.tgz",
-      "integrity": "sha512-KszivGSj50g+zSc5nfXxvJUR1hRmRZ+OgmsfH5i8RwVxhQpa35QQ5vrp5P8lrM/H5BSA27JFtEbR7WL3E8K3fg==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.8.0"
-      }
-    },
-    "opentelemetry-instrumentation-kafkajs": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-kafkajs/-/opentelemetry-instrumentation-kafkajs-0.35.0.tgz",
-      "integrity": "sha512-mhB37umd+ONX1s64yXScgx7abl2n1Mm6mNXWycR1/+mQqvvkLPHbz3Qa3axsPd7J9EQ0+I405z6lR011HCTGZQ==",
-      "requires": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.8.0"
-      }
-    },
-    "opentelemetry-instrumentation-sequelize": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-sequelize/-/opentelemetry-instrumentation-sequelize-0.35.0.tgz",
-      "integrity": "sha512-bYcw98dFTbAGcGzIwNa+09mnW7tRgew0qR9L09oo3X3+L6NtA3C6GxGVGBa9ExxHJeokSl5F5ytSMTYVUG4iBA==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.8.0"
-      }
-    },
-    "opentelemetry-instrumentation-typeorm": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-typeorm/-/opentelemetry-instrumentation-typeorm-0.35.0.tgz",
-      "integrity": "sha512-7hBE3olNNBy0gGWH+Fx/TuYbPKOC+yAIucG9bUJ/wT1xeD0ZR6CtZZMQjyN4eDLVZ0ay+3BLguWbBJAbtARWSg==",
-      "requires": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.8.0",
-        "is-promise": "^4.0.0"
-      }
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
-    },
-    "pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="
-    },
-    "pg-protocol": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
-    },
-    "pg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "requires": {
-        "pg-int8": "1.0.1",
-        "postgres-array": "~2.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.4",
-        "postgres-interval": "^1.1.0"
-      }
-    },
-    "postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="
-    },
-    "postgres-bytea": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w=="
-    },
-    "postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="
-    },
-    "postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "requires": {
-        "xtend": "^4.0.0"
-      }
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "protobufjs": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
-      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
-      },
-      "dependencies": {
-        "long": {
-          "version": "5.2.3",
-          "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-          "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
-    },
-    "require-in-the-middle": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
-      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
-      "requires": {
-        "debug": "^4.1.1",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.1"
-      }
-    },
-    "resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
-      "requires": {
-        "is-core-module": "^2.11.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
-    "semver": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.0.tgz",
-      "integrity": "sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
-    },
-    "shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-    },
-    "sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ=="
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "requires": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      }
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
-    },
-    "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "requires": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      }
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
-    },
-    "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-    },
-    "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "requires": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      }
-    },
-    "yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
     }
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@opentelemetry/instrumentation-aws-lambda": "0.35.0",
     "@opentelemetry/resource-detector-aws": "1.2.2",
-    "@opentelemetry/sdk-trace-node": "^1.10.1",
-    "@splunk/otel": "^2.2.2",
+    "@opentelemetry/sdk-trace-node": "^1.14.0",
+    "@splunk/otel": "^2.2.4",
     "@types/signalfx": "7.4.1"
   }
 }


### PR DESCRIPTION
Updated other dependencies as needed to minimize duplication and version consistency - unfortunately still can't update lambda instrumentation or resource detector without blowing up to 38 copies of `instrumentation` but this is still progress.