### PR TITLE
chore: upgrade to @splunk/otel 2.3.2

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@splunk/otel-lambda",
-  "version": "0.15.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel-lambda",
-      "version": "0.15.0",
+      "version": "0.14.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "@splunk/otel-lambda",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@splunk/otel-lambda",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation-aws-lambda": "0.35.0",
-        "@opentelemetry/resource-detector-aws": "1.2.2",
-        "@opentelemetry/sdk-trace-node": "^1.14.0",
-        "@splunk/otel": "^2.2.4",
+        "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
+        "@opentelemetry/resource-detector-aws": "1.3.0",
+        "@opentelemetry/sdk-trace-node": "1.15.2",
+        "@splunk/otel": "2.3.2",
         "@types/signalfx": "7.4.1"
       },
       "devDependencies": {
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.8.17",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.8.17.tgz",
-      "integrity": "sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
+      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
@@ -36,14 +36,14 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.7.tgz",
-      "integrity": "sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==",
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
+      "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
       "dependencies": {
         "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
         "long": "^4.0.0",
-        "protobufjs": "^7.0.0",
+        "protobufjs": "^7.2.4",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -146,9 +146,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.40.0.tgz",
-      "integrity": "sha512-8WRuvGnfnbeR9ifGjLN8kklk2fkd0gBT6aN7NHO9zeYF/6qacAViD3bwAKqGXKnJgl39l1EU41I9diqUjamEEQ==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.41.2.tgz",
+      "integrity": "sha512-JEV2RAqijAFdWeT6HddYymfnkiRu2ASxoTBr4WsnGJhOjWZkEy6vp+Sx9ozr1NaIODOa2HUyckExIqQjn6qywQ==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -157,12 +157,9 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.15.0.tgz",
-      "integrity": "sha512-sfxQOyAyV3WsKswGX0Yx3P+e7t3EtxpF/PC+6e4+rqs88oUfTaP3214iz4GQuuzV9yCG8DRWTZ96J6E/iD0qeA==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.15.2.tgz",
+      "integrity": "sha512-VAMHG67srGFQDG/N2ns5AyUT9vUcoKpZ/NpJ5fDQIPfJd7t3ju+aHwvDsMcrYBWuCh03U3Ky6o16+872CZchBg==",
       "engines": {
         "node": ">=14"
       },
@@ -171,12 +168,11 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.0.tgz",
-      "integrity": "sha512-GGTS6BytfaN8OgbCUOnxg/a9WVsVUj0484zXHZuBzvIXx7V4Tmkb0IHnnhS7Q0cBLNLgjNuvrCpQaP8fIvO4bg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
+      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -186,129 +182,55 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.40.0.tgz",
-      "integrity": "sha512-1kIEi2G4uVrxqZV+9M09Il2XeylAUOpNXg1vpS50R2CgP99u6ICzu+xhENXWucaVya+tRduwrhkVzSagyP7Mtw==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.41.2.tgz",
+      "integrity": "sha512-gQuCcd5QSMkfi1XIriWAoak/vaRvFzpvtzh2hjziIvbnA3VtoGD3bDb2dzEzOA1iSWO0/tHwnBsSmmUZsETyOA==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.40.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.40.0",
-        "@opentelemetry/otlp-transformer": "0.40.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/sdk-metrics": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.41.2",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-metrics": "1.15.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.40.0.tgz",
-      "integrity": "sha512-4ferfcHOyYAhy+7Xk/vMWGBI6yafeOxpLWKrRjzNFAGKzD78teOnPTvyaCecPF0nviTF4VuwT2ECgon6Q/bFBQ==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.41.2.tgz",
+      "integrity": "sha512-+YeIcL4nuldWE89K8NBLImpXCvih04u1MBnn8EzvoywG2TKR5JC3CZEPepODIxlsfGSgP8W5khCEP1NHZzftYw==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/otlp-exporter-base": "0.40.0",
-        "@opentelemetry/otlp-transformer": "0.40.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/sdk-metrics": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-metrics": "1.15.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.40.0.tgz",
-      "integrity": "sha512-Xmh+lUEbxrNGgma9ABdHarr6ICxhrPcFP5gJBjMufdknh1tox7H97GZndtYF2ic5v2Kk0fC1c+j9tKFd4JWDPg==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.41.2.tgz",
+      "integrity": "sha512-OLNs6wF84uhxn8TJ8Bv1q2ltdJqjKA9oUEtICcUDDzXIiztPxZ9ur/4xdMk9T3ZJeFMfrhj8eYDkpETBy+fjCg==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.40.0",
-        "@opentelemetry/otlp-exporter-base": "0.40.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.40.0",
-        "@opentelemetry/otlp-transformer": "0.40.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/sdk-metrics": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.41.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-metrics": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -317,126 +239,36 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.40.0.tgz",
-      "integrity": "sha512-/UW/6s1WBHkFgdwizouUCEGZPt7NE0Y5xpuFuHqQF/KyjcHzTWibXzB/XWOSS81X55FUxrI3Icoeptk7vtxJFQ==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.41.2.tgz",
+      "integrity": "sha512-tRM/mq7PFj7mXCws5ICMVp/rmgU93JvZdoLE0uLj4tugNz231u2ZgeRYXulBjdeHM88ZQSsWTJMu2mvr/3JV1A==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.40.0",
-        "@opentelemetry/otlp-transformer": "0.40.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/sdk-trace-base": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
-      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.40.0.tgz",
-      "integrity": "sha512-1bICfJOrBF+Q+4UYjI0X3brZftLmzPEmVV78/fAiMIEM+DpAYYXW4dEPGL9ta8J5hYI3XXZkwnB3bfeyRA58AQ==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.41.2.tgz",
+      "integrity": "sha512-IGZga9IIckqYE3IpRE9FO9G5umabObIrChlXUHYpMJtDgx797dsb3qXCvLeuAwB+HoB8NsEZstlzmLnoa6/HmA==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/otlp-exporter-base": "0.40.0",
-        "@opentelemetry/otlp-proto-exporter-base": "0.40.0",
-        "@opentelemetry/otlp-transformer": "0.40.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/sdk-trace-base": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
+        "@opentelemetry/otlp-transformer": "0.41.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -445,66 +277,15 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
-      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.35.1.tgz",
-      "integrity": "sha512-EZsvXqxenbRTSNsft6LDcrT4pjAiyZOx3rkDNeqKpwZZe6GmZtsXaZZKuDkJtz9fTjOGjDHjZj9/h80Ya9iIJw==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
+      "integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
       "dependencies": {
-        "require-in-the-middle": "^5.0.3",
-        "semver": "^7.3.2",
+        "@types/shimmer": "^1.0.2",
+        "import-in-the-middle": "1.4.2",
+        "require-in-the-middle": "^7.1.1",
+        "semver": "^7.5.1",
         "shimmer": "^1.2.1"
       },
       "engines": {
@@ -515,13 +296,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.32.2.tgz",
-      "integrity": "sha512-NSXvRKtJhBqkKQltmOicg0ChyAA5VfrKPa9WSrFDXvlw8Pjs9UiQQTEYbiBT3V5LSjJXH6CpNnQp6v2bqEldow==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.33.0.tgz",
+      "integrity": "sha512-2EQ1db0xq9lHayPR7pszFEzojkvxhERIMv6vu4GHICmQCDuhvGQ4JpwOuX5KdmJr54LqKjqmL1na2s1bRKJzNQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -531,15 +313,16 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.35.0.tgz",
-      "integrity": "sha512-x6nd1DEf/MYU57AMphwyxQLSPSNit6lnJAMNz9eQmQ0TdzGaWUsWUz2OgoZXzjF2D8hbaJHYaDvl1IUOk7cNVg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.36.0.tgz",
+      "integrity": "sha512-GkehkjN4vHTc5HNIBlKddrm+EVch2cNEfbLcV7tXLu0Hu95kt6PPOwxHDYRxgvu1auFpJY0epUzmPd11zI706A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/propagator-aws-xray": "^1.2.0",
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/propagator-aws-xray": "^1.3.0",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/aws-lambda": "8.10.81"
+        "@types/aws-lambda": "8.10.81",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -549,14 +332,15 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.34.0.tgz",
-      "integrity": "sha512-DT7Z08MVNOk/kyvztV1l4s1YMjW4qTbw852EhKkgpyYeKkxfGwdHqvv6+7MzOboJPXFQv/ADn1zcPtD8Lqia/Q==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.35.0.tgz",
+      "integrity": "sha512-jKf2nuTe3kYhtINGmgaVlw54q5pgX959zK2abGdvoUSdSP3Pv36YwNZk1K+jAKCN4I71R8/Qp1driAuKKj/Kxg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/propagation-utils": "^0.29.2",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/propagation-utils": "^0.30.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -566,12 +350,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.31.1.tgz",
-      "integrity": "sha512-y81y0L50ocziES+jVcsCM684R+1p3M64bfGwVumZI/cH3LNSlnvOd4xgQom4Ug+UzcYcP9RxjFURDQAvh8tnDw==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.32.0.tgz",
+      "integrity": "sha512-c2Fi12NMBPRNyzeMXjY3kmgJcu8T2TIR051S+EEnXP677+aJhUrzAPpIDEqJ3RITMemxS44NmDFnnG+p0zdUbg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@types/bunyan": "1.8.7"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@types/bunyan": "1.8.7",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -581,12 +366,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.32.1.tgz",
-      "integrity": "sha512-28tbhM8I7Yp7PfSRnykxMFHKDsJC5efwOOoI/CehxIITSLOLrenmCEeNhSUfVUHzMIiqFiZXW/F0wurbAy38pg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.33.0.tgz",
+      "integrity": "sha512-JlCb7SKRadeDDrIlsjuaBDRXKIRPW4yC1W3zfh9UBIEgG3SPK1QyPt1jaXqmjrd6RuOx8f5tOZB/HsYAgeiqUw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -596,14 +382,15 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.31.1.tgz",
-      "integrity": "sha512-72hDzkUIpq4TFrBi0yooNH/LVQbiGZ3wgL0uVGjvyTfN1ZOfoa5LhverWwtfAcjn1aniVU4xEL6aWqGl0A3nDQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.32.0.tgz",
+      "integrity": "sha512-aNntYZ8VX04fm0QhZb1n1YkszxeLRGPWaHroMmsVjGS/zAcAeic5tb4EzNHddkAtv+wj5K9snKeGWwg9Wm5LpQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/connect": "3.4.35"
+        "@types/connect": "3.4.35",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -613,11 +400,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.4.0.tgz",
-      "integrity": "sha512-t12pWySH7d5Kmo9CZDAPs22d40kzWHyvMFsQGysc7UVtBOXB+Vg7Bzt4j3R4jdal/WkGKRgXL920zhGmziuzxw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.5.0.tgz",
+      "integrity": "sha512-PygtCdOGuf8rkLmctGrq0y8g7u3h1kbaaYoR6SxnVuxLal/ELP78eiAbEwElEGLGRy5oWava5VAIhEys5wfGqw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -627,13 +415,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.31.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.31.2.tgz",
-      "integrity": "sha512-BBfMzbJGdEEz/OX2uPq0u9NAX2HL9KZ5x3PqwnJEqnUnRBr8hHJ9xbbY9WKRxZ55cGt8XeQpkj2NbRNkoy4hzQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.32.0.tgz",
+      "integrity": "sha512-Q6RHePHnMQdKsAKzKvPSN0nPfKVlzFlbPa9/nb3r0FhThCP/Ucjob138X4LEDy0ZyZs3mq8Vqr9riyyRHIW6iA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "semver": "^7.3.2"
+        "semver": "^7.3.2",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -643,14 +432,15 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.32.1.tgz",
-      "integrity": "sha512-MR5ondudJaBG+GscjTWp3dm+mUacWgD9CnFs+EURNzd4EfHpPcxB9ZtFgUfzsp6FMJQZvOsgN5/fHQ4wmkf/fg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.33.0.tgz",
+      "integrity": "sha512-Cem3AssubzUoBK5ab89rBt2kY90i/FFyQwMC9wPjBQldkOaT4cR+5ufvWritXRfoPltqEeX2imLavujNH6EzCw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/express": "4.17.13"
+        "@types/express": "4.17.13",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -660,13 +450,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.31.1.tgz",
-      "integrity": "sha512-oROINVKIvkkX3wQidPOYH78ruHwvfVBIi74svkeNaMzZ78xW2Djb/BiA5tXAujhi+fRGl2kwCG580iS9q5G7YA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.0.tgz",
+      "integrity": "sha512-M0zRI5+FfA2UnNk9YSeofhZkM5X46w2lDW/1pVahpIlfyPoEbOdRO2YrfR6Y9t9emR62IKk4tN/IcSgXIK2RRg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -676,13 +467,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.31.1.tgz",
-      "integrity": "sha512-FvoQKVpafcXvsJvIQU3QOFx/KBwbCblIGW83JWwoz2ymMu1coSJTveqN7cNVqEMR3BZ0eN4Ljgmq3AvimWXiTg==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.32.0.tgz",
+      "integrity": "sha512-oJaxI3dobPHO8/CwrJKAC6UKWONoFq07GiuEfy7wyTE0QtZtKsPbCQ6vYI+cwx4NPlEpbPcvbaeNCE8gTALlCA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/generic-pool": "^3.1.9"
+        "@types/generic-pool": "^3.1.9",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -692,11 +484,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.34.0.tgz",
-      "integrity": "sha512-vRlaxApRW2FuWTsUE/0rrfgk7aQiOPQZDLlG5KIMvC+ExCT0bw//09D5GskUKU596CZy4j/n9WBOBc+Wu5zweA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.35.0.tgz",
+      "integrity": "sha512-hKuOXTzB8UBaxVteKU2nMRGnUPt6bD9SSBBLYaDOGGPF1Gs4XsiuMMRuyXomMIudelM7flPpbuqiP9YoSJuXQQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -706,12 +499,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.35.1.tgz",
-      "integrity": "sha512-EBmpCD+5QfUXPmupynjwxt3tUG5bgTrGZT12B0/+By9ZMLboDAryHjpiermanbPh5mTOq0q73YzruGQWU9TExg==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.41.2.tgz",
+      "integrity": "sha512-+fh9GUFv97p25CMreUv4OdP5L21hPgfX3d4fuQ0KIgIZIaX2M6/8cr5Ik+8zWsyhYzfFX3CKq6BXm3UBg7cswQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.35.1",
-        "@opentelemetry/semantic-conventions": "1.9.1"
+        "@opentelemetry/instrumentation": "0.41.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -720,23 +513,16 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
-      "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.31.1.tgz",
-      "integrity": "sha512-kk/LdhIb/5AC48xHq1LzoV6My7TgEAANxsIXQwLiIUVBgM5yjH3bEb5TjyqbSVNvqsJ1aU5etQICjKbSNh+zlA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.32.0.tgz",
+      "integrity": "sha512-Wl43lSVqqJZAxhWE1BWlV9yoInEOGiKeGqNhphoGJLqblmlF8Yxob1t2fK/wTj2srmmm1XU70olwhN09uOQxpg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/hapi__hapi": "20.0.9"
+        "@types/hapi__hapi": "20.0.9",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -746,14 +532,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.35.1.tgz",
-      "integrity": "sha512-tH92LznX5pcxpuTSb6A662IdldlMk8QTtneDN66h4nIT9ch98Gtu68GSSKjMoTR25GzH3opvPC9mX2xJamxMJw==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.41.2.tgz",
+      "integrity": "sha512-dzOC6xkfK0LM6Dzo91aInLdSbdIzKA0IgSDnyLi6YZ0Z7c1bfrFncFx/3gZs8vi+KXLALgfMlpzE7IYDW/cM3A==",
       "dependencies": {
-        "@opentelemetry/core": "1.9.1",
-        "@opentelemetry/instrumentation": "0.35.1",
-        "@opentelemetry/semantic-conventions": "1.9.1",
-        "semver": "^7.3.5"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/instrumentation": "0.41.2",
+        "@opentelemetry/semantic-conventions": "1.15.2",
+        "semver": "^7.5.1"
       },
       "engines": {
         "node": ">=14"
@@ -762,37 +548,16 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-6/qon6tw2I8ZaJnHAQUUn4BqhTbTNRS0WP8/bA0ynaX+Uzp/DDbd0NS0Cq6TMlh8+mrlsyqDE7mO50nmv2Yvlg==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.9.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.9.1.tgz",
-      "integrity": "sha512-oPQdbFDmZvjXk5ZDoBGXG8B4tSB/qW5vQunJWQMFUBp7Xe8O1ByPANueJ+Jzg58esEBegyyxZ7LRmfJr7kFcFg==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.34.0.tgz",
-      "integrity": "sha512-2oEOcsqBHGxt4fDV3lM8vxCZNKv2E7ChChSctu4IPem4ixT4vCBm1oEVDU2/6RcS6vnNS6XtbhCchQtKjUMQyA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.35.0.tgz",
+      "integrity": "sha512-tdM1BkrYmx+fXH+t1DViTXqFr9LUJHl0Qdcr6G8PjscsK+bVssSHhi5a3zYPFFFHpjks1mXMZHMr/Vsj2hNQAw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/redis-common": "^0.35.0",
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/redis-common": "^0.36.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
+        "@types/ioredis4": "npm:@types/ioredis@^4.28.10",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -802,12 +567,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.31.1.tgz",
-      "integrity": "sha512-X9SIdzmyyoknPwUB+/JfcF8VHujQWxXDNMKl3PpxU2PwEaKpXPKtOgdA7do08tSoULMI0xCftFIzBUFnWivPFQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.32.0.tgz",
+      "integrity": "sha512-451Ct/vD4v/7M9yyk69FdQ8CCaC57xAWSJkqq0vyQfARekEiQiIXUpaddJ8OXEwX/vYvR9RbSDa6A5a0uNhi4A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -817,15 +583,16 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.34.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.34.3.tgz",
-      "integrity": "sha512-WHPl7MMmeFeM1Mg9kgCU64Zdc6MXwXXw9qnJV4Ajl/7zX6/XyGEatDcTMxaJAzVQKXSHR70lKfl8+/W/UP2wrw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.35.0.tgz",
+      "integrity": "sha512-Q/KclXdHKE3sGlalxxX43lx4b8eY5lv5LSdG3mY8aBsrmw1Mx6Cv4VAeqA4ecCygeapTmf9jjOLmgro15IJ3AQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/koa": "2.13.6",
-        "@types/koa__router": "8.0.7"
+        "@types/koa__router": "8.0.7",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -835,13 +602,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.31.1.tgz",
-      "integrity": "sha512-uDiLLTsXlXLIvwYdl9+1AvxvWZkYrXAIvHwPOi6FthznnDIJtyxk0DgxusUaezhRUS9W1CqO5hFb1+8Hmg5DCQ==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.32.0.tgz",
+      "integrity": "sha512-EZsgK71ZqZugmyqbMA7XDURAtBPaVXkh7Ez2bcfA6Vw2l/ZUslozexTBbRbHGPAvw8DlevcYcZzpB/SreVDqvA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/memcached": "^2.2.6"
+        "@types/memcached": "^2.2.6",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -851,12 +619,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.34.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.34.1.tgz",
-      "integrity": "sha512-zRmotNkUQF6G9KWMEr2K2xZSqlaYKLY4HvV+DGHtOeJ1NbRUFk0V5XBNpB6nc4dXiEJUlGfXRyrQ/yu5TKiUuA==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.36.0.tgz",
+      "integrity": "sha512-bisDLBO0JqydPh4rkgrbYhnFOd4T2ZAnFAnBFll9TB1jJEHTeeobdBThuwxvur5q5ZfbjevreUcMydG6UBNMaA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/sdk-metrics": "^1.9.1",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -866,13 +636,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.32.1.tgz",
-      "integrity": "sha512-ibTM94JpTM6nbfARoql0wLWFOOchCIlDAhSibFNxQ+TImWLZxVQ6NpNnrtbrNoUoPD0xnB/ZlYR7as72Xu4Vyg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.33.0.tgz",
+      "integrity": "sha512-IB4zCJ7vsiILx5hjPH7PtlvKIVN84m3rER8zu7xeaMpfpzD5/khj6et0x1aE+KzPS49nIOZx3qmH67MocSNevg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14.0"
@@ -882,14 +653,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.33.0.tgz",
-      "integrity": "sha512-dU0phFuwtI81M7HyHbr/N4OllEAWYbQaOtSaJnDPMCxy4f840Np1kPzcTcAqd6zYIMhaO3B1nt7N2cP3ftu2RQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.34.0.tgz",
+      "integrity": "sha512-muBzhaSk3to1XK2aSMFTP9lW6YALebQ8ick9raDBESiLf8JREZDJWVlhfaigeJGBk53tUBZ3Ty1g1Cfe15+OhQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@types/mysql": "2.15.19",
-        "mysql": "2.18.1"
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -899,12 +670,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.33.1.tgz",
-      "integrity": "sha512-ZyGg2KAaQRTctjCUIo+s25Yl4WDAvReF//EA0vKb9nKxMafon1NEbWeO1+qIE6xiXRXFUFn80hnf0N/YLu5gvw==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.34.0.tgz",
+      "integrity": "sha512-wEJ9BcZTT/60a69V5GS/XlQx+JyoOKKYYR/kdZ2p/XY/UI+kELPSWiLZAR00YLYi33g0zVZlKG3gfHU1KFn5sQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -914,12 +686,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.32.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.32.2.tgz",
-      "integrity": "sha512-nUidxCbRnN+QUKArl5f8rE3hkYTsYlHEZRoWMqH9fFsVxOdZ4S6kT/HP55/Pj9+cDZ6XfBbelEOZjpsYeO2dYg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.33.0.tgz",
+      "integrity": "sha512-/c1nipi2XLt2TQlFpKNof44o99H7BmdOWiZBAdIATJpvOKPbn+Ggt4OQQdtmxFyzMX13dTxgtpQ5RX2Orvxz2Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -929,12 +702,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.31.1.tgz",
-      "integrity": "sha512-Gfks0UUi076w7aSTX1Q7KfnmlSqt0vMX0sc6jUWRd/BOQo/r84aS/DU0dP1FuPLyC4Vzpx9pPCnD37MRPhbkKA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.32.0.tgz",
+      "integrity": "sha512-fIgmkTpkdDXlRKUC4X2SdpJJof+KCA7feiBlLXHJ6xcaqBWG/6mt25A1FTyaJiXRWPhk+faGhtMxT0WX2AD3kQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -944,15 +718,17 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.35.0.tgz",
-      "integrity": "sha512-vNcnILF9c+SJVZr0R0xKY9HzbATLwRVbKrrIbkD6Oj4uzfarlA6n2bF3LJAYGMMcDSdxUN+KaTMeW9byLKqqTg==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.36.0.tgz",
+      "integrity": "sha512-S9RmzTILWTl7AVfdp/e8lWQTlpwrpoPbpxAfEJ1ENzTlPMmdw0jWPAQTgrTLQa6cpzhiypDHts3g2b6hc1zFYQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
+        "@opentelemetry/sql-common": "^0.40.0",
         "@types/pg": "8.6.1",
-        "@types/pg-pool": "2.0.3"
+        "@types/pg-pool": "2.0.3",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -962,11 +738,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.33.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.33.1.tgz",
-      "integrity": "sha512-Rajum1USKFE3khFSg7JRqoI+2BK2BpC2SiB0mjXdQ5s31IxaNuc6qiXdNz6mRzbdzMb/ydsJchlQiSNwB2iVeQ==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.34.0.tgz",
+      "integrity": "sha512-UtoVJG1gVit5Bksy0ccwtmJm9a39WDW4tMEAh0Spk31burJuEKKT09CslSQ3zmkoHj91iLWi5O5A94dIUVIXsg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -976,13 +753,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.34.4.tgz",
-      "integrity": "sha512-X1iX75gcQGImLRGZ7s7vbgKy3zIwgZO9fECq7jDnSjBoQ2WxTs8BMN/J2wqEE4SUawxzbHxQqcvAXEy3zA4r0A==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.0.tgz",
+      "integrity": "sha512-WXUjuTtDbV9e27xDtdi9ObjGeJnD8YI2FSb7Bu7yqrqU2c/AUDjUbLAtjxG5otfaRZbLEP57KrjHu5N5V5NzNg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/redis-common": "^0.35.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/redis-common": "^0.36.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -992,13 +770,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.34.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.34.3.tgz",
-      "integrity": "sha512-JdHK/retw8rttFkv393P07PEtxhaPLbWXWSJC8Y9kBAoZ+vFEMTM5z+vPQTfgcBQFveyy6v6GEa6H1ozd35z7w==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.35.0.tgz",
+      "integrity": "sha512-jCtYP3Cu3PcWzETFzdMn3iET1M9cXYihvwsSECq3bMKLUewY+Acc5jCycJyvnO/yZbEF2cDQS3m3UAdAVlG8Pw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/redis-common": "^0.35.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/redis-common": "^0.36.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1008,13 +787,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.32.1.tgz",
-      "integrity": "sha512-eko2ESs93LA8G81+qaVsDsCMdvDvvtWJKILBbqJAUeas0WqdLvytcMv/KlXGrHkenTtHA+t1pyTOPw4uyxELsQ==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.33.0.tgz",
+      "integrity": "sha512-evDjcF6M9G+KH/GCjtUx9Vnm/CBZ9CBfmm/RP6Aeo20y6Kset1ZEoPK79JT7JK1sCPqViBPoj4qnFePz9/20lg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1024,12 +804,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-router": {
-      "version": "0.32.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.32.1.tgz",
-      "integrity": "sha512-hLj2+Io3jaLfknaXOLhZc/ITs0St29Kf/LGIpfUA067JKtf9YSXndlfvI731nFf6O0KzKWc9loD/mKvc9W4bWQ==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.33.0.tgz",
+      "integrity": "sha512-Dn/ARu14ePjtx0ejRJYvExt6y1wBchkAICv8JYOXRgNXWvFWBGTuucRc1Hwqk9YI8N4DYz1BVKe1sgJ3kBel6w==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1039,13 +820,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.5.1.tgz",
-      "integrity": "sha512-iDDF/ZtxoV6eGzOjVj5qnHJ88RpTg7SbRnrFjPQ4E8HaNEjlnMnig3LjIKESV6GZpPO2DVciqIBWSfs8x34RIw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.6.0.tgz",
+      "integrity": "sha512-dXTDFriaHOdL5X6MKNc4pno7GKJnatuNfvvXtzVHJY0+HAdc6c78PpnmFFAP8Uvoqp/eBsxYLd/fppl2HtxTrQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
+        "@opentelemetry/instrumentation": "^0.41.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/tedious": "^4.0.6"
+        "@types/tedious": "^4.0.6",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1055,11 +837,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.31.1.tgz",
-      "integrity": "sha512-qPK89Fp5bI6+IGMm2J2+A4kmeRfvRdrfgdwYlXoMZhO4aLL6BL5thdPYkDmIKO4FIzoOmybg62H3lMAExUUAyA==",
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.32.0.tgz",
+      "integrity": "sha512-Pf+tsLmccH/RrUXPiirPj7GhADP1X+21C5lOaYegpyHZgWGLvjCx7W/c89wQSol7DertSUKMB1iixQpUmVqDdQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1"
+        "@opentelemetry/instrumentation": "^0.41.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1069,88 +852,44 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.40.0.tgz",
-      "integrity": "sha512-AUmMUPM1/oYGbOWYRBBQz4Ic/adMYA/mIMnAy+QAEmCzjBIC/fyRReVhJmF2cpkvYh7QOkX3017zl2dgWLHpvQ==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.41.2.tgz",
+      "integrity": "sha512-pfwa6d+Dax3itZcGWiA0AoXeVaCuZbbqUTsCtOysd2re8C2PWXNxDONUfBWsn+KgxAdi+ljwTjJGiaVLDaIEvQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0"
+        "@opentelemetry/core": "1.15.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.40.0.tgz",
-      "integrity": "sha512-rgfyCofGMpou1OsCF1fNr/2iBzgeZj3rjplEBi0yfX6s3nNcJ6ZfhDvyblKG6dd/UydPSHYAtFAstZwwuucFJA==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.41.2.tgz",
+      "integrity": "sha512-OErK8dYjXG01XIMIpmOV2SzL9ctkZ0Nyhf2UumICOAKtgLvR5dG1JMlsNVp8Jn0RzpsKc6Urv7JpP69wzRXN+A==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/otlp-exporter-base": "0.40.0",
-        "protobufjs": "^7.2.2"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "protobufjs": "^7.2.3"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.40.0.tgz",
-      "integrity": "sha512-Wc3Nrmi/BBffrRPgf4ic1jrSnvLEd3+vb2sytDDBzRM97Oobx6RI1Y6bDkCN9pI/VRBaaFap8qT9riVec0MIug==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.41.2.tgz",
+      "integrity": "sha512-BxmEMiP6tHiFroe5/dTt9BsxCci7BTLtF7A6d4DKHLiLweWWZxQ9l7hON7qt/IhpKrQcAFD1OzZ1Gq2ZkNzhCw==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/otlp-exporter-base": "0.40.0",
-        "protobufjs": "^7.1.2"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "protobufjs": "^7.2.3"
       },
       "engines": {
         "node": ">=14"
@@ -1159,39 +898,17 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.40.0.tgz",
-      "integrity": "sha512-YrJgVVAsJHibENSbYmC1x+5jAmkAGZ9yrgmHxc6IyqM3D1mryhqBvMRDD31JoavPYelkS7dmrXWM8g7swX0B+g==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.41.2.tgz",
+      "integrity": "sha512-jJbPwB0tNu2v+Xi0c/v/R3YBLJKLonw1p+v3RVjT2VfzeUyzSp/tBeVdY7RZtL6dzZpA9XSmp8UEfWIFQo33yA==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.40.0",
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/sdk-logs": "0.40.0",
-        "@opentelemetry/sdk-metrics": "1.14.0",
-        "@opentelemetry/sdk-trace-base": "1.14.0"
+        "@opentelemetry/api-logs": "0.41.2",
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-logs": "0.41.2",
+        "@opentelemetry/sdk-metrics": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -1200,63 +917,13 @@
         "@opentelemetry/api": ">=1.3.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
-      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.29.5",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.29.5.tgz",
-      "integrity": "sha512-TRVQAZZfXmatJ8ZrjtQadxv+3n1DbQl42aK2/UOeZ0THdz9EqQ2+IBbvPD484c8H7pjUVUwqDOsk+1BOSPwXEw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.0.tgz",
+      "integrity": "sha512-gQ90Ry0aIcnnEckFCJlq/TAXnNYlH/Ff9qMQFCMI9oni3J7futG2k4SdrR3fS6D4cH2XwbenWxypt85cBaOv9A==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
         "node": ">=14"
       },
@@ -1265,11 +932,12 @@
       }
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.2.1.tgz",
-      "integrity": "sha512-xGPBHXwMvrFuRUfyWj6HEUuQX/QSblN3pcGila/wX01/9KYO5TgFvwKOqR9uxLqvS1s/NaF8J1afsieYCGp7Tg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.3.0.tgz",
+      "integrity": "sha512-0DrsBY/Fy12J+0wTxNOui2eunO5SIrSzf+k3kNeIh2EhPr8Y9Pd1XwOtRm5vooly0W+Oxkzk5U2vpz4dKQOBqQ==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0"
+        "@opentelemetry/core": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1279,12 +947,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.15.0.tgz",
-      "integrity": "sha512-YafSIITpCmo76VdlJ/GvS5x+uuRWCU5BqCOV9CITi11Tk4aqTxMR3pXlMoPYQWstUUgacQf4dGcdvdS+1rkDWQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.15.2.tgz",
+      "integrity": "sha512-ZSrL3DpMEDsjD8dPt9Ze3ue53nEXJt512KyxXlLgLWnSNbe1mrWaXWkh7OLDoVJh9LqFw+tlvAhDVt/x3DaFGg==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -1294,12 +961,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.15.0.tgz",
-      "integrity": "sha512-OU6WNxuqjxNZoRcIBCsmvTBktAPuBUj1bh+DI+oYAvzwP2NXLavSDJWjVMGTJQDgZuR7lFijmx9EfwyAO9x37Q==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.15.2.tgz",
+      "integrity": "sha512-6m1yu7PVDIRz6BwA36lacfBZJCfAEHKgu+kSyukNwVdVjsTNeyD9xNPQnkl0WN7Rvhk8/yWJ83tLPEyGhk1wCQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -1309,21 +975,25 @@
       }
     },
     "node_modules/@opentelemetry/redis-common": {
-      "version": "0.35.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.35.1.tgz",
-      "integrity": "sha512-qLXe7h9VzFLx3LaizFiUlpuohCRyvHlDW5b9synE6omHKTZr/n0EHEdmhp3GezBeAqMGI+q499Mht4SmStaSqQ==",
+      "version": "0.36.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.0.tgz",
+      "integrity": "sha512-rTKuBszerwzKm0uBmffJ8j47+5YBGu6HGUWnez5gev2B4by8TKkY37E/QMq7/3KRL9NkZ08VJCtl3piCCFW30g==",
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.2.2.tgz",
-      "integrity": "sha512-DFnv0z+D+t224wOS+0rsEfvxqKLKFm0DYHDSuam68JKJ7pDbfpyBWhRc4fzDc/J6JT0LtPT4iMJcytQUiGEOwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.0.tgz",
+      "integrity": "sha512-fF1cMnR2ObMThJVkF4nUkTmmIbzMkrKs3ibEALs6sD3b6VqCZ8NafnX/GS+VpmguVevyGqFr/mLSdehNkm9ABg==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0"
+        "@opentelemetry/semantic-conventions": "^1.0.0",
+        "tslib": "^2.3.1"
       },
       "engines": {
         "node": ">=14"
@@ -1333,13 +1003,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.0.tgz",
-      "integrity": "sha512-Sb8A6ZXHXDlgHv32UNRE3y8McWE3vkb5dsSttYArYa5ZpwjiF5ge0vnnKUUnG7bY0AgF9VBIOORZE8gsrnD2WA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
+      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -1349,12 +1018,12 @@
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.40.0.tgz",
-      "integrity": "sha512-/JG7DOLo/Y3VR9azPXlXNRGQff3gp7nQbWl5cFD2SmlYqUrzMq1OjbksZLVztDu1+ynbFunseUG11SxhoxvSRg==",
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.41.2.tgz",
+      "integrity": "sha512-smqKIw0tTW15waj7BAPHFomii5c3aHnSE4LQYTszGoK5P9nZs8tEAIpu15UBxi3aG31ZfsLmm4EUQkjckdlFrw==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -1364,51 +1033,14 @@
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.14.0.tgz",
-      "integrity": "sha512-F0JXmLqT4LmsaiaE28fl0qMtc5w0YuMWTHt1hnANTNX8hxW4IKSv9+wrYG7BZd61HEbPm032Re7fXyzzNA6nIw==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.2.tgz",
+      "integrity": "sha512-9aIlcX8GnhcsAHW/Wl8bzk4ZnWTpNlLtud+fxUfBtFATu6OZ6TrGrF4JkT9EVrnoxwtPIDtjHdEsSjOqisY/iA==",
       "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "lodash.merge": "4.6.2"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "lodash.merge": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
@@ -1417,52 +1049,14 @@
         "@opentelemetry/api": ">=1.3.0 <1.5.0"
       }
     },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.0.tgz",
-      "integrity": "sha512-udt1c9VHipbZwvCPIQR1VLg25Z4AMR/g0X8KmcInbFruGWQ/lptVPkz3yvWAsGSta5yHNQ3uoPwcyCygGnQ6Lg==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
+      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/resources": "1.15.0",
-        "@opentelemetry/semantic-conventions": "1.15.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2"
       },
       "engines": {
         "node": ">=14"
@@ -1472,17 +1066,16 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.15.0.tgz",
-      "integrity": "sha512-TKBx9oThZUVKkoGpXhFT/XUgpjq28TWwc6j3JlsL+cJX77DKBnVC+2H+kdVVJHRzyfqDx4LEJJVCwQO3K+cbXA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.15.2.tgz",
+      "integrity": "sha512-5deakfKLCbPpKJRCE2GPI8LBE2LezyvR17y3t37ZI3sbaeogtyxmBaFV+slmG9fN8OaIT+EUsm1QAT1+z59gbQ==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.15.0",
-        "@opentelemetry/core": "1.15.0",
-        "@opentelemetry/propagator-b3": "1.15.0",
-        "@opentelemetry/propagator-jaeger": "1.15.0",
-        "@opentelemetry/sdk-trace-base": "1.15.0",
-        "semver": "^7.5.1",
-        "tslib": "^2.3.1"
+        "@opentelemetry/context-async-hooks": "1.15.2",
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/propagator-b3": "1.15.2",
+        "@opentelemetry/propagator-jaeger": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2",
+        "semver": "^7.5.1"
       },
       "engines": {
         "node": ">=14"
@@ -1492,14 +1085,25 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.0.tgz",
-      "integrity": "sha512-f3wwFrFyCpGrFBrFs7lCUJSCSCGyeKG52c+EKeobs3Dd29M75yO6GYkt6PkYPfDawxSlV5p+4yJPPk8tPObzTQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
+      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.0.tgz",
+      "integrity": "sha512-vSqRJYUPJVjMFQpYkQS3ruexCPSZJ8esne3LazLwtCPaPRvzZ7WG3tX44RouAn7w4wMp8orKguBqtt+ng2UTnw==",
       "dependencies": {
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "^1.1.0"
       },
       "engines": {
         "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1575,184 +1179,70 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@splunk/otel": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.2.4.tgz",
-      "integrity": "sha512-9ghXHlX//jGTmmTNHGRpxXmqkOUebaU+1gmjcMC+5gV0Mf3nyDVxCpHNdYjh2Reg7gjUcHSJ6d9AE4R8LxRxLA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.3.2.tgz",
+      "integrity": "sha512-4hVZ0SrH5RAd/dgle9MV3r8bZtEVDma5SfDPWe7ZZdP/3iLqnwSFMMihTbgXAk1duW94wEbYwC5xdRltyAIqqQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@grpc/grpc-js": "^1.8.11",
-        "@grpc/proto-loader": "^0.7.6",
+        "@grpc/grpc-js": "^1.8.19",
+        "@grpc/proto-loader": "^0.7.8",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-async-hooks": "1.14.0",
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.40.0",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.40.0",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.40.0",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.40.0",
-        "@opentelemetry/instrumentation": "0.35.1",
-        "@opentelemetry/instrumentation-amqplib": "0.32.2",
-        "@opentelemetry/instrumentation-aws-sdk": "0.34.0",
-        "@opentelemetry/instrumentation-bunyan": "0.31.1",
-        "@opentelemetry/instrumentation-cassandra-driver": "0.32.1",
-        "@opentelemetry/instrumentation-connect": "0.31.1",
-        "@opentelemetry/instrumentation-dataloader": "0.4.0",
-        "@opentelemetry/instrumentation-dns": "0.31.2",
-        "@opentelemetry/instrumentation-express": "0.32.1",
-        "@opentelemetry/instrumentation-fastify": "0.31.1",
-        "@opentelemetry/instrumentation-generic-pool": "0.31.1",
-        "@opentelemetry/instrumentation-graphql": "0.34.0",
-        "@opentelemetry/instrumentation-grpc": "0.35.1",
-        "@opentelemetry/instrumentation-hapi": "0.31.1",
-        "@opentelemetry/instrumentation-http": "0.35.1",
-        "@opentelemetry/instrumentation-ioredis": "0.34.0",
-        "@opentelemetry/instrumentation-knex": "0.31.1",
-        "@opentelemetry/instrumentation-koa": "0.34.3",
-        "@opentelemetry/instrumentation-memcached": "0.31.1",
-        "@opentelemetry/instrumentation-mongodb": "0.34.1",
-        "@opentelemetry/instrumentation-mongoose": "0.32.1",
-        "@opentelemetry/instrumentation-mysql": "0.33.0",
-        "@opentelemetry/instrumentation-mysql2": "0.33.1",
-        "@opentelemetry/instrumentation-nestjs-core": "0.32.2",
-        "@opentelemetry/instrumentation-net": "0.31.1",
-        "@opentelemetry/instrumentation-pg": "0.35.0",
-        "@opentelemetry/instrumentation-pino": "0.33.1",
-        "@opentelemetry/instrumentation-redis": "0.34.4",
-        "@opentelemetry/instrumentation-redis-4": "0.34.3",
-        "@opentelemetry/instrumentation-restify": "0.32.1",
-        "@opentelemetry/instrumentation-router": "0.32.1",
-        "@opentelemetry/instrumentation-tedious": "0.5.1",
-        "@opentelemetry/instrumentation-winston": "0.31.1",
-        "@opentelemetry/propagator-b3": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/sdk-metrics": "1.14.0",
-        "@opentelemetry/sdk-trace-base": "1.14.0",
-        "@opentelemetry/sdk-trace-node": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0",
+        "@opentelemetry/context-async-hooks": "1.15.2",
+        "@opentelemetry/core": "1.15.2",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.41.2",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.41.2",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.41.2",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.41.2",
+        "@opentelemetry/instrumentation": "0.41.2",
+        "@opentelemetry/instrumentation-amqplib": "0.33.0",
+        "@opentelemetry/instrumentation-aws-sdk": "0.35.0",
+        "@opentelemetry/instrumentation-bunyan": "0.32.0",
+        "@opentelemetry/instrumentation-cassandra-driver": "0.33.0",
+        "@opentelemetry/instrumentation-connect": "0.32.0",
+        "@opentelemetry/instrumentation-dataloader": "0.5.0",
+        "@opentelemetry/instrumentation-dns": "0.32.0",
+        "@opentelemetry/instrumentation-express": "0.33.0",
+        "@opentelemetry/instrumentation-fastify": "0.32.0",
+        "@opentelemetry/instrumentation-generic-pool": "0.32.0",
+        "@opentelemetry/instrumentation-graphql": "0.35.0",
+        "@opentelemetry/instrumentation-grpc": "0.41.2",
+        "@opentelemetry/instrumentation-hapi": "0.32.0",
+        "@opentelemetry/instrumentation-http": "0.41.2",
+        "@opentelemetry/instrumentation-ioredis": "0.35.0",
+        "@opentelemetry/instrumentation-knex": "0.32.0",
+        "@opentelemetry/instrumentation-koa": "0.35.0",
+        "@opentelemetry/instrumentation-memcached": "0.32.0",
+        "@opentelemetry/instrumentation-mongodb": "0.36.0",
+        "@opentelemetry/instrumentation-mongoose": "0.33.0",
+        "@opentelemetry/instrumentation-mysql": "0.34.0",
+        "@opentelemetry/instrumentation-mysql2": "0.34.0",
+        "@opentelemetry/instrumentation-nestjs-core": "0.33.0",
+        "@opentelemetry/instrumentation-net": "0.32.0",
+        "@opentelemetry/instrumentation-pg": "0.36.0",
+        "@opentelemetry/instrumentation-pino": "0.34.0",
+        "@opentelemetry/instrumentation-redis": "0.35.0",
+        "@opentelemetry/instrumentation-redis-4": "0.35.0",
+        "@opentelemetry/instrumentation-restify": "0.33.0",
+        "@opentelemetry/instrumentation-router": "0.33.0",
+        "@opentelemetry/instrumentation-tedious": "0.6.0",
+        "@opentelemetry/instrumentation-winston": "0.32.0",
+        "@opentelemetry/propagator-b3": "1.15.2",
+        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/sdk-metrics": "1.15.2",
+        "@opentelemetry/sdk-trace-base": "1.15.2",
+        "@opentelemetry/sdk-trace-node": "1.15.2",
+        "@opentelemetry/semantic-conventions": "1.15.2",
+        "is-promise": "^4.0.0",
         "nan": "^2.17.0",
         "node-gyp-build": "^4.6.0",
-        "opentelemetry-instrumentation-elasticsearch": "^0.35.0",
-        "opentelemetry-instrumentation-kafkajs": "^0.35.0",
-        "opentelemetry-instrumentation-sequelize": "^0.35.0",
-        "opentelemetry-instrumentation-typeorm": "^0.35.0",
-        "protobufjs": "^7.2.2",
-        "semver": "^7.5.3"
+        "protobufjs": "^7.2.4",
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@splunk/otel/node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.14.0.tgz",
-      "integrity": "sha512-KfwMzdjxUtQM3uy4ogEdN3pdakFreyZNybKKlvxUM+inF5tAObsGamlmsfmUt6s3mXEC70+DY743+TdG4FMf/Q==",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@splunk/otel/node_modules/@opentelemetry/core": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.14.0.tgz",
-      "integrity": "sha512-MnMZ+sxsnlzloeuXL2nm5QcNczt/iO82UOeQQDHhV83F2fP3sgntW2evvtoxJki0MBLxEsh5ADD7PR/Hn5uzjw==",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@splunk/otel/node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.14.0.tgz",
-      "integrity": "sha512-E05zrq0FxbalwJen8XZVfVclKmc5aqvGhMuSfXkbQ3IXC3EE1IcmJXX3T1Fum2JgeUlOt7FM90kaRG0BZ8Bgow==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@splunk/otel/node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.14.0.tgz",
-      "integrity": "sha512-B70+npZ9atPdRZjZ/KY5+aiHhK1h/8kqEoPfI6p5Pv0lMgi1aCXwi8w0Cjtm89nV3OhfwNCyuR6dhoFadvO0Ew==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@splunk/otel/node_modules/@opentelemetry/resources": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.14.0.tgz",
-      "integrity": "sha512-qRfWIgBxxl3z47E036Aey0Lj2ZjlFb27Q7Xnj1y1z/P293RXJZGLtcfn/w8JF7v1Q2hs3SDGxz7Wb9Dko1YUQA==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@splunk/otel/node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.14.0.tgz",
-      "integrity": "sha512-NzRGt3PS+HPKfQYMb6Iy8YYc5OKA73qDwci/6ujOIvyW9vcqBJSWbjZ8FeLEAmuatUB5WrRhEKu9b0sIiIYTrQ==",
-      "dependencies": {
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/resources": "1.14.0",
-        "@opentelemetry/semantic-conventions": "1.14.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@splunk/otel/node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.14.0.tgz",
-      "integrity": "sha512-t+batuETp4RBje4F5hdzPTEk/Pg/f5hu+4+x0nkUve+MVqee1yzQrly7KhwcCAlDoMjXB0cwiLBm0NcWbAW5Vw==",
-      "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.14.0",
-        "@opentelemetry/core": "1.14.0",
-        "@opentelemetry/propagator-b3": "1.14.0",
-        "@opentelemetry/propagator-jaeger": "1.14.0",
-        "@opentelemetry/sdk-trace-base": "1.14.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
-      }
-    },
-    "node_modules/@splunk/otel/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.14.0.tgz",
-      "integrity": "sha512-rJfCY8rCWz3cb4KI6pEofnytvMPuj3YLQwoscCCYZ5DkdiPjo15IQ0US7+mjcWy9H3fcZIzf2pbJZ7ck/h4tug==",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@types/accepts": {
@@ -1963,9 +1453,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.4.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.0.tgz",
-      "integrity": "sha512-jfT7iTf/4kOQ9S7CHV9BIyRaQqHu67mOjsIQBC3BKZvzvUB6zLxEwJ6sBE3ozcvP8kF6Uk5PXN0Q+c0dfhGX0g=="
+      "version": "20.4.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
+      "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ=="
     },
     "node_modules/@types/pg": {
       "version": "8.6.1",
@@ -2014,6 +1504,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/shimmer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.2.tgz",
+      "integrity": "sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg=="
+    },
     "node_modules/@types/signalfx": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/@types/signalfx/-/signalfx-7.4.1.tgz",
@@ -2025,6 +1520,25 @@
       "integrity": "sha512-ipwFvfy9b2m0gjHsIX0D6NAAwGCKokzf5zJqUZHUGt+7uWVlBIy6n2eyMgiKQ8ChLFVxic/zwQUhjLYNzbHDRA==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+      "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/ansi-regex": {
@@ -2049,13 +1563,10 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/bignumber.js": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-      "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-      "engines": {
-        "node": "*"
-      }
+    "node_modules/cjs-module-lexer": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
+      "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -2085,11 +1596,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -2152,15 +1658,21 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    "node_modules/import-in-the-middle": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.4.2.tgz",
+      "integrity": "sha512-9WOz1Yh/cvO/p69sxRmhyQwrIGGSp7EIdcb+fFNVi7CzQGQB8U1/1XrKVSbEd/GNOAeM0peJtmi7+qphe7NvAw==",
+      "dependencies": {
+        "acorn": "^8.8.2",
+        "acorn-import-assertions": "^1.9.0",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
-      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2180,11 +1692,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/joi": {
       "version": "17.9.2",
@@ -2234,20 +1741,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/mysql": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.18.1.tgz",
-      "integrity": "sha512-Bca+gk2YWmqp2Uf6k5NFEurwY/0td0cpebAucFpY/3jhrwrVGuxU2uQFCHjU19SJfje0yQvi+rVWdq78hR5lig==",
-      "dependencies": {
-        "bignumber.js": "9.0.0",
-        "readable-stream": "2.3.7",
-        "safe-buffer": "5.1.2",
-        "sqlstring": "2.3.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
@@ -2261,58 +1754,6 @@
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
         "node-gyp-build-test": "build-test.js"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-elasticsearch": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-elasticsearch/-/opentelemetry-instrumentation-elasticsearch-0.35.0.tgz",
-      "integrity": "sha512-KszivGSj50g+zSc5nfXxvJUR1hRmRZ+OgmsfH5i8RwVxhQpa35QQ5vrp5P8lrM/H5BSA27JFtEbR7WL3E8K3fg==",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.8.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-kafkajs": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-kafkajs/-/opentelemetry-instrumentation-kafkajs-0.35.0.tgz",
-      "integrity": "sha512-mhB37umd+ONX1s64yXScgx7abl2n1Mm6mNXWycR1/+mQqvvkLPHbz3Qa3axsPd7J9EQ0+I405z6lR011HCTGZQ==",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.8.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-sequelize": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-sequelize/-/opentelemetry-instrumentation-sequelize-0.35.0.tgz",
-      "integrity": "sha512-bYcw98dFTbAGcGzIwNa+09mnW7tRgew0qR9L09oo3X3+L6NtA3C6GxGVGBa9ExxHJeokSl5F5ytSMTYVUG4iBA==",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.8.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/opentelemetry-instrumentation-typeorm": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/opentelemetry-instrumentation-typeorm/-/opentelemetry-instrumentation-typeorm-0.35.0.tgz",
-      "integrity": "sha512-7hBE3olNNBy0gGWH+Fx/TuYbPKOC+yAIucG9bUJ/wT1xeD0ZR6CtZZMQjyN4eDLVZ0ay+3BLguWbBJAbtARWSg==",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.35.1",
-        "@opentelemetry/semantic-conventions": "^1.8.0",
-        "is-promise": "^4.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/path-parse": {
@@ -2383,11 +1824,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/protobufjs": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
@@ -2416,20 +1852,6 @@
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
-    "node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2439,24 +1861,24 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
-      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.2.0.tgz",
+      "integrity": "sha512-3TLx5TGyAY6AOqLBoXmHkNql0HIf2RGbuMgCDT2WO/uGVAPJs6h7Kl+bN6TIZGd9bWhWPwnDnTHGtW8Iu77sdw==",
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
         "resolve": "^1.22.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -2467,15 +1889,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2490,22 +1907,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
-    },
-    "node_modules/sqlstring": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.1.tgz",
-      "integrity": "sha512-ooAzh/7dxIG5+uDik1z/Rd1vli0+38izZhGzSa34FwR7IbelPWCCKSNIl8jlL/F7ERvy8CB2jNeM1E9i9mXMAQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2559,11 +1960,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel-lambda",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Layer including OpenTelemetry SDK for use with AWS Lambda enhanced by Splunk.",
   "repository": "git@github.com:signalfx/splunk-otel-lambda.git",
   "author": "Splunk <splunk-oss@splunk.com>",
@@ -28,10 +28,10 @@
     "typescript": "4.9"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation-aws-lambda": "0.35.0",
-    "@opentelemetry/resource-detector-aws": "1.2.2",
-    "@opentelemetry/sdk-trace-node": "^1.14.0",
-    "@splunk/otel": "^2.2.4",
+    "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
+    "@opentelemetry/resource-detector-aws": "1.3.0",
+    "@opentelemetry/sdk-trace-node": "1.15.2",
+    "@splunk/otel": "2.3.2",
     "@types/signalfx": "7.4.1"
   }
 }

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@splunk/otel-lambda",
-  "version": "0.15.0",
+  "version": "0.14.0",
   "description": "Layer including OpenTelemetry SDK for use with AWS Lambda enhanced by Splunk.",
   "repository": "git@github.com:signalfx/splunk-otel-lambda.git",
   "author": "Splunk <splunk-oss@splunk.com>",


### PR DESCRIPTION
There should no longer be any duplicate OpenTelemetry packages. I've pinned the deps to exact versions as splunk-otel-js now pins deps to exact versions as well due to the mess that is OTel versioning. Even new patch versions can bring in new duplicate packages.