### PR TITLE
chore: update to splunk-otel-js 2.4.0

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -13,7 +13,7 @@
         "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
         "@opentelemetry/resource-detector-aws": "1.3.0",
         "@opentelemetry/sdk-trace-node": "1.15.2",
-        "@splunk/otel": "2.3.2",
+        "@splunk/otel": "2.4.0",
         "@types/signalfx": "7.4.1"
       },
       "devDependencies": {
@@ -1179,9 +1179,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@splunk/otel": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.3.2.tgz",
-      "integrity": "sha512-4hVZ0SrH5RAd/dgle9MV3r8bZtEVDma5SfDPWe7ZZdP/3iLqnwSFMMihTbgXAk1duW94wEbYwC5xdRltyAIqqQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.4.0.tgz",
+      "integrity": "sha512-+gsgDIpo3znq1uUKoej4aw+9coqxKb9/DKEZbzdgZw5i7qpuuVd6R8z0hCouxiK7+13fR/pHbzsnM3L9jB11tQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.8.19",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -31,7 +31,7 @@
     "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
     "@opentelemetry/resource-detector-aws": "1.3.0",
     "@opentelemetry/sdk-trace-node": "1.15.2",
-    "@splunk/otel": "2.3.2",
+    "@splunk/otel": "2.4.0",
     "@types/signalfx": "7.4.1"
   }
 }


### PR DESCRIPTION
From the changelog:
* Fix the error message about an unavailable exporter (e.g. `Exporter "otlp" requested through environment variable is unavailable.`) when OTEL_TRACES_EXPORTER is set. Workaround for https://github.com/open-telemetry/opentelemetry-js/issues/3422. `splunk-otel-lambda` always set `OTEL_TRACES_EXPORTER`, so the users always saw this error even though nothing went wrong. https://github.com/signalfx/splunk-otel-js/pull/783
* **Fix for AWS Lambda instrumentation and a few others where they were logging unnecessary errors when `MeterProvider` wasn't set:** https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-aws-lambda/src/instrumentation.ts#L348-L354 Explicitly set a meter provider for instrumentations. NoopMeterProvider is set by default. If metrics are enabled and SPLUNK_INSTRUMENTATION_METRICS_ENABLED is set to true, instrumentation specific metrics will be emitted, for example http.server.duration from the http instrumentation. https://github.com/signalfx/splunk-otel-js/pull/784