### PR TITLE
chore: upgrade to splunk-otel-js 2.4.1

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -13,7 +13,7 @@
         "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
         "@opentelemetry/resource-detector-aws": "1.3.0",
         "@opentelemetry/sdk-trace-node": "1.15.2",
-        "@splunk/otel": "2.4.0",
+        "@splunk/otel": "2.4.1",
         "@types/signalfx": "7.4.1"
       },
       "devDependencies": {
@@ -1179,9 +1179,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@splunk/otel": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.4.0.tgz",
-      "integrity": "sha512-+gsgDIpo3znq1uUKoej4aw+9coqxKb9/DKEZbzdgZw5i7qpuuVd6R8z0hCouxiK7+13fR/pHbzsnM3L9jB11tQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.4.1.tgz",
+      "integrity": "sha512-/fOBVKGGlJJ+UGxxRxDYlwvMaPyZk3Xd7cX86In0Stf6vovvZeKOua/6VPT9l/Amr5drN21vXeIQfGLym5HKng==",
       "hasInstallScript": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.8.19",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -31,7 +31,7 @@
     "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
     "@opentelemetry/resource-detector-aws": "1.3.0",
     "@opentelemetry/sdk-trace-node": "1.15.2",
-    "@splunk/otel": "2.4.0",
+    "@splunk/otel": "2.4.1",
     "@types/signalfx": "7.4.1"
   }
 }


### PR DESCRIPTION
Contains a fix for AWS Lambda instrumentation to avoid the `Metrics may not be exported for the lambda function because we are not force flushing before callback.` error message