### PR TITLE
chore: upgrade to splunk/otel 2.4.2

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -13,7 +13,7 @@
         "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
         "@opentelemetry/resource-detector-aws": "1.3.0",
         "@opentelemetry/sdk-trace-node": "1.15.2",
-        "@splunk/otel": "2.4.1",
+        "@splunk/otel": "2.4.2",
         "@types/signalfx": "7.4.1"
       },
       "devDependencies": {
@@ -1179,9 +1179,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@splunk/otel": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.4.1.tgz",
-      "integrity": "sha512-/fOBVKGGlJJ+UGxxRxDYlwvMaPyZk3Xd7cX86In0Stf6vovvZeKOua/6VPT9l/Amr5drN21vXeIQfGLym5HKng==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.4.2.tgz",
+      "integrity": "sha512-9P5rBhFZXZ8FH6Y7rp47GbYvK3WiJ8Mzm2BjMmQFLzu+zmqu0UH0lPAJR4jRTsaBXig2fkDtWP3PLVM6AbeilQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.8.19",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -31,7 +31,7 @@
     "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
     "@opentelemetry/resource-detector-aws": "1.3.0",
     "@opentelemetry/sdk-trace-node": "1.15.2",
-    "@splunk/otel": "2.4.1",
+    "@splunk/otel": "2.4.2",
     "@types/signalfx": "7.4.1"
   }
 }


### PR DESCRIPTION
Adds support for `OTEL_METRICS_EXPORTER=none` which splunk-otel-lambda was setting. When metrics were enabled and `none` was set, this caused an invalid configuration value error.

Custom metrics should work after this now.