### PR TITLE
Oct 2023 version updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+- Updated node to splunk-otel 2.5.0
+- Updated upstream otel-lambda to latest
+
 ## 0.7.0
 
 - Updated upstream otel-lambda to latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Updated node to splunk-otel 2.5.0
 - Updated upstream otel-lambda to latest
+- Updated java dependencies, including otel-java sdk 1.30
 
 ## 0.7.0
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "com.diffplug.spotless" version "6.21.0" apply false
+    id "com.diffplug.spotless" version "6.22.0" apply false
 }
 
 group = 'com.splunk.public'
@@ -8,8 +8,8 @@ description = "Splunk distribution of OpenTelemetry Lambda"
 
 ext {
     versions = [
-            opentelemetry: '1.29.0',
-            opentelemetryalpha: '1.29.0-alpha'
+            opentelemetry: '1.30.0',
+            opentelemetryalpha: '1.30.0-alpha'
     ]
 }
 
@@ -52,7 +52,7 @@ dependencies {
     // lambda logging
     implementation("com.amazonaws:aws-lambda-java-log4j2:1.5.1")
     implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.18.0")
-    implementation("org.apache.logging.log4j:log4j-core:2.20.0")
+    implementation("org.apache.logging.log4j:log4j-core:2.21.1")
 }
 
 // need to exclude "parent" dependencies to avoid clash upon copy / zip of the final layer

--- a/java/settings.gradle
+++ b/java/settings.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.enterprise' version '3.15'
+    id 'com.gradle.enterprise' version '3.15.1'
 }
 
 gradleEnterprise {

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -10,11 +10,11 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
-        "@opentelemetry/resource-detector-aws": "1.3.0",
-        "@opentelemetry/sdk-trace-node": "1.15.2",
-        "@splunk/otel": "2.4.2",
-        "@types/signalfx": "7.4.1"
+        "@opentelemetry/instrumentation-aws-lambda": "0.37.1",
+        "@opentelemetry/resource-detector-aws": "1.3.2",
+        "@opentelemetry/sdk-trace-node": "1.17.1",
+        "@splunk/otel": "2.5.0",
+        "@types/signalfx": "7.4.3"
       },
       "devDependencies": {
         "typescript": "4.9"
@@ -24,11 +24,11 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.0.tgz",
-      "integrity": "sha512-H8+iZh+kCE6VR/Krj6W28Y/ZlxoZ1fOzsNt77nrdE3knkbSelW1Uus192xOFCxHyeszLj8i4APQkSIXjAoOxXg==",
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.7.tgz",
+      "integrity": "sha512-yMaA/cIsRhGzW3ymCNpdlPcInXcovztlgu/rirThj2b87u3RzWUszliOqZ/pldy7yhmJPS8uwog+kZSTa4A0PQ==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.0",
+        "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
       },
       "engines": {
@@ -36,13 +36,12 @@
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.8.tgz",
-      "integrity": "sha512-GU12e2c8dmdXb7XUlOgYWZ2o2i+z9/VeACkxTA/zzAe2IjclC5PnVL0lpgjhrqfpDYHzM8B1TF6pqWegMYAzlA==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
       "dependencies": {
-        "@types/long": "^4.0.1",
         "lodash.camelcase": "^4.3.0",
-        "long": "^4.0.0",
+        "long": "^5.0.0",
         "protobufjs": "^7.2.4",
         "yargs": "^17.7.2"
       },
@@ -138,17 +137,17 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.4.1.tgz",
-      "integrity": "sha512-O2yRJce1GOc6PAy3QxFM4NzFiWzvScDC1/5ihYBL6BUEVdq0XMWN01sppE+H6bBXbaFYipjwFLEWLg5PaSOThA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
+      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.41.2.tgz",
-      "integrity": "sha512-JEV2RAqijAFdWeT6HddYymfnkiRu2ASxoTBr4WsnGJhOjWZkEy6vp+Sx9ozr1NaIODOa2HUyckExIqQjn6qywQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.44.0.tgz",
+      "integrity": "sha512-OctojdKGmXHKAJa4/Ml+Nf7MD9jtYXvZyP64xTh0pNTmtgaTdWW3FURri2DdB/+l7YxRy0tYYZS3/tYEM1pj3w==",
       "dependencies": {
         "@opentelemetry/api": "^1.0.0"
       },
@@ -157,42 +156,42 @@
       }
     },
     "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.15.2.tgz",
-      "integrity": "sha512-VAMHG67srGFQDG/N2ns5AyUT9vUcoKpZ/NpJ5fDQIPfJd7t3ju+aHwvDsMcrYBWuCh03U3Ky6o16+872CZchBg==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.17.1.tgz",
+      "integrity": "sha512-up5I+RiQEkGrVEHtbAtmRgS+ZOnFh3shaDNHqZPBlGy+O92auL6yMmjzYpSKmJOGWowvs3fhVHePa8Exb5iHUg==",
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.15.2.tgz",
-      "integrity": "sha512-+gBv15ta96WqkHZaPpcDHiaz0utiiHZVfm2YOYSqFGrUaJpPkMoSuLBB58YFQGi6Rsb9EHos84X6X5+9JspmLw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.17.1.tgz",
+      "integrity": "sha512-I6LrZvl1FF97FQXPR0iieWQmKnGxYtMbWA1GrAXnLUR+B1Hn2m8KqQNEIlZAucyv00GBgpWkpllmULmZfG8P3g==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.15.2"
+        "@opentelemetry/semantic-conventions": "1.17.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.41.2.tgz",
-      "integrity": "sha512-gQuCcd5QSMkfi1XIriWAoak/vaRvFzpvtzh2hjziIvbnA3VtoGD3bDb2dzEzOA1iSWO0/tHwnBsSmmUZsETyOA==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.44.0.tgz",
+      "integrity": "sha512-7A2Ed7mKsa2edRUS8Au5susMNGHeiO/LNxc/XC73g848aBF8Xo8xlNWnV78fa+EYJZLzEKDzts4vpKgtwyvo/Q==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.41.2",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.41.2",
-        "@opentelemetry/otlp-transformer": "0.41.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/sdk-metrics": "1.15.2"
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.44.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.44.0",
+        "@opentelemetry/otlp-transformer": "0.44.0",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/sdk-metrics": "1.17.1"
       },
       "engines": {
         "node": ">=14"
@@ -202,15 +201,15 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.41.2.tgz",
-      "integrity": "sha512-+YeIcL4nuldWE89K8NBLImpXCvih04u1MBnn8EzvoywG2TKR5JC3CZEPepODIxlsfGSgP8W5khCEP1NHZzftYw==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.44.0.tgz",
+      "integrity": "sha512-OiEkP9XWbh5ufjnP+xe8EQ2LShMY5f1NYBm9W/BgLaHPtlMNZnR7JB1t6Ut4gaZ7LA/yFnyrB0TnZcxntpBZ3Q==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/otlp-exporter-base": "0.41.2",
-        "@opentelemetry/otlp-transformer": "0.41.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/sdk-metrics": "1.15.2"
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/otlp-exporter-base": "0.44.0",
+        "@opentelemetry/otlp-transformer": "0.44.0",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/sdk-metrics": "1.17.1"
       },
       "engines": {
         "node": ">=14"
@@ -220,17 +219,17 @@
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.41.2.tgz",
-      "integrity": "sha512-OLNs6wF84uhxn8TJ8Bv1q2ltdJqjKA9oUEtICcUDDzXIiztPxZ9ur/4xdMk9T3ZJeFMfrhj8eYDkpETBy+fjCg==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.44.0.tgz",
+      "integrity": "sha512-GnxFAtb42OkE8sHmty5Ex5rEOfS+psAhCUq/Jod+7ZKMwUrxGvUWAa3nS9CkihhL2lj4rBU7o8SV8TO0Nn85/A==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/exporter-metrics-otlp-http": "0.41.2",
-        "@opentelemetry/otlp-exporter-base": "0.41.2",
-        "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
-        "@opentelemetry/otlp-transformer": "0.41.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/sdk-metrics": "1.15.2"
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.44.0",
+        "@opentelemetry/otlp-exporter-base": "0.44.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.44.0",
+        "@opentelemetry/otlp-transformer": "0.44.0",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/sdk-metrics": "1.17.1"
       },
       "engines": {
         "node": ">=14"
@@ -240,16 +239,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.41.2.tgz",
-      "integrity": "sha512-tRM/mq7PFj7mXCws5ICMVp/rmgU93JvZdoLE0uLj4tugNz231u2ZgeRYXulBjdeHM88ZQSsWTJMu2mvr/3JV1A==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.44.0.tgz",
+      "integrity": "sha512-S1kT/9tVlgZDRYyVfCLYyWZoQTplPD9WcyX+qUPbhJTETORxzJVW9HN8mHwQsXaN7ngqwRLy5GW/nXHL8aqA0w==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/otlp-grpc-exporter-base": "0.41.2",
-        "@opentelemetry/otlp-transformer": "0.41.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/sdk-trace-base": "1.15.2"
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.44.0",
+        "@opentelemetry/otlp-transformer": "0.44.0",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/sdk-trace-base": "1.17.1"
       },
       "engines": {
         "node": ">=14"
@@ -259,16 +258,16 @@
       }
     },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.41.2.tgz",
-      "integrity": "sha512-IGZga9IIckqYE3IpRE9FO9G5umabObIrChlXUHYpMJtDgx797dsb3qXCvLeuAwB+HoB8NsEZstlzmLnoa6/HmA==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.44.0.tgz",
+      "integrity": "sha512-yVW0FXxiLaQOyE3MGr6BtK7ml0DaJH4Qx3yvQYUd/hsJUSZBhYYw2TRaMsaW7XMpe1AvU81qt0l8uLYmcmcLJA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/otlp-exporter-base": "0.41.2",
-        "@opentelemetry/otlp-proto-exporter-base": "0.41.2",
-        "@opentelemetry/otlp-transformer": "0.41.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/sdk-trace-base": "1.15.2"
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/otlp-exporter-base": "0.44.0",
+        "@opentelemetry/otlp-proto-exporter-base": "0.44.0",
+        "@opentelemetry/otlp-transformer": "0.44.0",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/sdk-trace-base": "1.17.1"
       },
       "engines": {
         "node": ">=14"
@@ -278,14 +277,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.41.2.tgz",
-      "integrity": "sha512-rxU72E0pKNH6ae2w5+xgVYZLzc5mlxAbGzF4shxMVK8YC2QQsfN38B2GPbj0jvrKWWNUElfclQ+YTykkNg/grw==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.44.0.tgz",
+      "integrity": "sha512-B6OxJTRRCceAhhnPDBshyQO7K07/ltX3quOLu0icEvPK9QZ7r9P1y0RQX8O5DxB4vTv4URRkxkg+aFU/plNtQw==",
       "dependencies": {
         "@types/shimmer": "^1.0.2",
         "import-in-the-middle": "1.4.2",
         "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.1",
+        "semver": "^7.5.2",
         "shimmer": "^1.2.1"
       },
       "engines": {
@@ -296,14 +295,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.33.0.tgz",
-      "integrity": "sha512-2EQ1db0xq9lHayPR7pszFEzojkvxhERIMv6vu4GHICmQCDuhvGQ4JpwOuX5KdmJr54LqKjqmL1na2s1bRKJzNQ==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.33.2.tgz",
+      "integrity": "sha512-qAc9DMkyStlc45LgM+krSckYL4O5zi3uu1rk1QQL7Nn6q3LNNZV2c+fUPMf7hDf2OuK6VyVF0rqWYDSu/JDJ6Q==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -313,16 +311,15 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.36.0.tgz",
-      "integrity": "sha512-GkehkjN4vHTc5HNIBlKddrm+EVch2cNEfbLcV7tXLu0Hu95kt6PPOwxHDYRxgvu1auFpJY0epUzmPd11zI706A==",
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.37.1.tgz",
+      "integrity": "sha512-tIz6SnvKXEjRId0yXcYNJL8CX5uY4Ou3yIkBeb1WSADLjNCp0NW1VaUM2pm8ksW3Nr3/0PY9S5T2yUBVr3yBIg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/propagator-aws-xray": "^1.3.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/propagator-aws-xray": "^1.3.1",
         "@opentelemetry/resources": "^1.8.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/aws-lambda": "8.10.81",
-        "tslib": "^2.3.1"
+        "@types/aws-lambda": "8.10.122"
       },
       "engines": {
         "node": ">=14"
@@ -332,15 +329,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-sdk": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.35.0.tgz",
-      "integrity": "sha512-jKf2nuTe3kYhtINGmgaVlw54q5pgX959zK2abGdvoUSdSP3Pv36YwNZk1K+jAKCN4I71R8/Qp1driAuKKj/Kxg==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.36.1.tgz",
+      "integrity": "sha512-OpWI7erB1f3ncaLqyqhXrrR4bF2rK4la0z63WvX4SRlFBxOpLnVKj0RLdEbxnp7i+0zfEeC+Z4Sqt99MkKcDJA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/propagation-utils": "^0.30.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/propagation-utils": "^0.30.2",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -350,13 +346,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-bunyan": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.32.0.tgz",
-      "integrity": "sha512-c2Fi12NMBPRNyzeMXjY3kmgJcu8T2TIR051S+EEnXP677+aJhUrzAPpIDEqJ3RITMemxS44NmDFnnG+p0zdUbg==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.32.2.tgz",
+      "integrity": "sha512-/sLChixYxFas7c5SbLLGUq2yKmU8c58IPlYNNqRSiT0epouqeBjxNUwQeizXl6Ba5+T/Yq7cwCVjh72CRb3tlA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@types/bunyan": "1.8.7",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@types/bunyan": "1.8.9"
       },
       "engines": {
         "node": ">=14"
@@ -366,13 +361,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-cassandra-driver": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.33.0.tgz",
-      "integrity": "sha512-JlCb7SKRadeDDrIlsjuaBDRXKIRPW4yC1W3zfh9UBIEgG3SPK1QyPt1jaXqmjrd6RuOx8f5tOZB/HsYAgeiqUw==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-cassandra-driver/-/instrumentation-cassandra-driver-0.33.2.tgz",
+      "integrity": "sha512-0tgIdRJk6tw8PIuRKM/pSQRwF1YGEaG+KxfT09Fxw0DBaxyoTgxgNzOHiYLx8zmoCzGTaLd79tHlrYWZRfXEGQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -382,15 +376,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.32.0.tgz",
-      "integrity": "sha512-aNntYZ8VX04fm0QhZb1n1YkszxeLRGPWaHroMmsVjGS/zAcAeic5tb4EzNHddkAtv+wj5K9snKeGWwg9Wm5LpQ==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.32.2.tgz",
+      "integrity": "sha512-wNbExeTGoDTvMfraByTy7GaX+6Dc5DmQ49lZoWO5EBmrpsKBaL8l9XYCPNKOa3dEp28d9oJWyx+ixHQ2OhDLcA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/connect": "3.4.35",
-        "tslib": "^2.3.1"
+        "@types/connect": "3.4.36"
       },
       "engines": {
         "node": ">=14"
@@ -400,12 +393,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.5.0.tgz",
-      "integrity": "sha512-PygtCdOGuf8rkLmctGrq0y8g7u3h1kbaaYoR6SxnVuxLal/ELP78eiAbEwElEGLGRy5oWava5VAIhEys5wfGqw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.5.2.tgz",
+      "integrity": "sha512-OYzh714M8szDayFP21eSGUZqQQjgLr7d1skjtbhzT4TIBYe2X7EpPM+4Rmkef+eZsBkCmUk/ecfwAQC+nfAJGg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0"
       },
       "engines": {
         "node": ">=14"
@@ -415,14 +407,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-dns": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.32.0.tgz",
-      "integrity": "sha512-Q6RHePHnMQdKsAKzKvPSN0nPfKVlzFlbPa9/nb3r0FhThCP/Ucjob138X4LEDy0ZyZs3mq8Vqr9riyyRHIW6iA==",
+      "version": "0.32.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dns/-/instrumentation-dns-0.32.3.tgz",
+      "integrity": "sha512-bBZW58MhfoIVCxKSeJexkbt1iclf0mgReJzKtldbU+pvD4OwSNLYmQ20OE+3YUKEX442CrjXI92Yg6ZF+EqKJQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "semver": "^7.3.2",
-        "tslib": "^2.3.1"
+        "semver": "^7.5.4"
       },
       "engines": {
         "node": ">=14"
@@ -432,15 +423,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.33.0.tgz",
-      "integrity": "sha512-Cem3AssubzUoBK5ab89rBt2kY90i/FFyQwMC9wPjBQldkOaT4cR+5ufvWritXRfoPltqEeX2imLavujNH6EzCw==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.33.2.tgz",
+      "integrity": "sha512-FR05iNosZL42haYang6vpmcuLfXLngJs/0gAgqXk8vwqGGwilOFak1PjoRdO4PAoso0FI+3zhV3Tz7jyDOmSyA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/express": "4.17.13",
-        "tslib": "^2.3.1"
+        "@types/express": "4.17.18"
       },
       "engines": {
         "node": ">=14"
@@ -450,14 +440,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-fastify": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.0.tgz",
-      "integrity": "sha512-M0zRI5+FfA2UnNk9YSeofhZkM5X46w2lDW/1pVahpIlfyPoEbOdRO2YrfR6Y9t9emR62IKk4tN/IcSgXIK2RRg==",
+      "version": "0.32.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fastify/-/instrumentation-fastify-0.32.3.tgz",
+      "integrity": "sha512-vRFVoEJXcu6nNpJ61H5syDb84PirOd4b3u8yl8Bcorrr6firGYBQH4pEIVB4PkQWlmi3sLOifqS3VAO2VRloEQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -467,14 +456,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.32.0.tgz",
-      "integrity": "sha512-oJaxI3dobPHO8/CwrJKAC6UKWONoFq07GiuEfy7wyTE0QtZtKsPbCQ6vYI+cwx4NPlEpbPcvbaeNCE8gTALlCA==",
+      "version": "0.32.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.32.3.tgz",
+      "integrity": "sha512-pJmmyKQzeROBtl0W+Gv1BHeVXixq8xdXtPy2IokEj33/sr++RfElixWMXRkar7suBkj9/c09a4fOj3fUrJJaYQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/generic-pool": "^3.1.9",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -484,12 +471,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.35.0.tgz",
-      "integrity": "sha512-hKuOXTzB8UBaxVteKU2nMRGnUPt6bD9SSBBLYaDOGGPF1Gs4XsiuMMRuyXomMIudelM7flPpbuqiP9YoSJuXQQ==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.35.2.tgz",
+      "integrity": "sha512-lJv7BbHFK0ExwogdQMtVHfnWhCBMDQEz8KYvhShXfRPiSStU5aVwa3TmT0O00KiJFpATSKJNZMv1iZNHbF6z1g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0"
       },
       "engines": {
         "node": ">=14"
@@ -499,12 +485,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-grpc": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.41.2.tgz",
-      "integrity": "sha512-+fh9GUFv97p25CMreUv4OdP5L21hPgfX3d4fuQ0KIgIZIaX2M6/8cr5Ik+8zWsyhYzfFX3CKq6BXm3UBg7cswQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-grpc/-/instrumentation-grpc-0.44.0.tgz",
+      "integrity": "sha512-ddj0cmC9mdyOTF2dieslRWsXvCeamGM3KGpYyFwdXBKwPnVCD5Y8zSCSplqIgqIU7B8avPHaHlPU9Li2OxMQjw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "0.41.2",
-        "@opentelemetry/semantic-conventions": "1.15.2"
+        "@opentelemetry/instrumentation": "0.44.0",
+        "@opentelemetry/semantic-conventions": "1.17.1"
       },
       "engines": {
         "node": ">=14"
@@ -514,15 +500,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.32.0.tgz",
-      "integrity": "sha512-Wl43lSVqqJZAxhWE1BWlV9yoInEOGiKeGqNhphoGJLqblmlF8Yxob1t2fK/wTj2srmmm1XU70olwhN09uOQxpg==",
+      "version": "0.33.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.33.1.tgz",
+      "integrity": "sha512-8gwPrIgppbj/prCTK31mGmcBvYESE5J2El6badbCvcUHg6ZSA/i8zo80NrJ6812imtD06Dvm6kfnK5UzlC+smQ==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/hapi__hapi": "20.0.9",
-        "tslib": "^2.3.1"
+        "@types/hapi__hapi": "20.0.13"
       },
       "engines": {
         "node": ">=14"
@@ -532,14 +517,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.41.2.tgz",
-      "integrity": "sha512-dzOC6xkfK0LM6Dzo91aInLdSbdIzKA0IgSDnyLi6YZ0Z7c1bfrFncFx/3gZs8vi+KXLALgfMlpzE7IYDW/cM3A==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.44.0.tgz",
+      "integrity": "sha512-Nlvj3Y2n9q6uIcQq9f33HbcB4Dr62erSwYA37+vkorYnzI2j9PhxKitocRTZnbYsrymYmQJW9mdq/IAfbtVnNg==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/instrumentation": "0.41.2",
-        "@opentelemetry/semantic-conventions": "1.15.2",
-        "semver": "^7.5.1"
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/instrumentation": "0.44.0",
+        "@opentelemetry/semantic-conventions": "1.17.1",
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=14"
@@ -549,15 +534,14 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.35.0.tgz",
-      "integrity": "sha512-tdM1BkrYmx+fXH+t1DViTXqFr9LUJHl0Qdcr6G8PjscsK+bVssSHhi5a3zYPFFFHpjks1mXMZHMr/Vsj2hNQAw==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.35.2.tgz",
+      "integrity": "sha512-D+KODK3ZzS9Be6zAzcoOyVd4Taf87CQ34jAX+FgrjtRlCxTuY6+p1eFhWNHWYS0EOcmdOcFcXxhszwp3/K1B4A==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/redis-common": "^0.36.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/redis-common": "^0.36.1",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/ioredis4": "npm:@types/ioredis@^4.28.10",
-        "tslib": "^2.3.1"
+        "@types/ioredis4": "npm:@types/ioredis@^4.28.10"
       },
       "engines": {
         "node": ">=14"
@@ -567,13 +551,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.32.0.tgz",
-      "integrity": "sha512-451Ct/vD4v/7M9yyk69FdQ8CCaC57xAWSJkqq0vyQfARekEiQiIXUpaddJ8OXEwX/vYvR9RbSDa6A5a0uNhi4A==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.32.2.tgz",
+      "integrity": "sha512-mEapkK4efIsCIGyuLcPpzA+dfPfw7w/kzS0zpm0Zm+tw1zjEGYoVubE0HzjmmexE4TOL6PzBSvF5FXOUXYH9XQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -583,16 +566,15 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.35.0.tgz",
-      "integrity": "sha512-Q/KclXdHKE3sGlalxxX43lx4b8eY5lv5LSdG3mY8aBsrmw1Mx6Cv4VAeqA4ecCygeapTmf9jjOLmgro15IJ3AQ==",
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.36.1.tgz",
+      "integrity": "sha512-wMbDk8qdU9MuOdz5GkHxxNCKPpiAu3RAU6Gf7Gj2ZmnDhxn1mCinaDm3Y2XyniRDzQu4+lFQszYTEdg84XcFYg==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/koa": "2.13.6",
-        "@types/koa__router": "8.0.7",
-        "tslib": "^2.3.1"
+        "@types/koa": "2.13.9",
+        "@types/koa__router": "12.0.1"
       },
       "engines": {
         "node": ">=14"
@@ -602,14 +584,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-memcached": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.32.0.tgz",
-      "integrity": "sha512-EZsgK71ZqZugmyqbMA7XDURAtBPaVXkh7Ez2bcfA6Vw2l/ZUslozexTBbRbHGPAvw8DlevcYcZzpB/SreVDqvA==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-memcached/-/instrumentation-memcached-0.32.2.tgz",
+      "integrity": "sha512-g3BsNXvxQr1Vz4ZqIboJK2QOow+t9bNdn8NXyaqI1uZFxVhaIYQJmK0Wt76ueHJ48SVzC1gbqNsGFIak5KhQEg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/memcached": "^2.2.6",
-        "tslib": "^2.3.1"
+        "@types/memcached": "^2.2.6"
       },
       "engines": {
         "node": ">=14"
@@ -619,14 +600,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.36.0.tgz",
-      "integrity": "sha512-bisDLBO0JqydPh4rkgrbYhnFOd4T2ZAnFAnBFll9TB1jJEHTeeobdBThuwxvur5q5ZfbjevreUcMydG6UBNMaA==",
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.37.1.tgz",
+      "integrity": "sha512-UE+5B/MDfB5MUlJfjj8uo/fMnJPpqeUesJZ/loAWuCLCTDDyEJM7wnAvtH+2c4QoukkkIT1lDe5q9aiXwLEr5g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/sdk-metrics": "^1.9.1",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -636,14 +616,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.33.0.tgz",
-      "integrity": "sha512-IB4zCJ7vsiILx5hjPH7PtlvKIVN84m3rER8zu7xeaMpfpzD5/khj6et0x1aE+KzPS49nIOZx3qmH67MocSNevg==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.33.2.tgz",
+      "integrity": "sha512-JXhhn8vkGKbev6aBPkQ6dL5rDImQfucrub8mU7dknPPpCL850fSQ2qt2qLvyDXfawF5my6KWW0fkKJCeRA+ECw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14.0"
@@ -653,14 +632,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.34.0.tgz",
-      "integrity": "sha512-muBzhaSk3to1XK2aSMFTP9lW6YALebQ8ick9raDBESiLf8JREZDJWVlhfaigeJGBk53tUBZ3Ty1g1Cfe15+OhQ==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.34.2.tgz",
+      "integrity": "sha512-3OEhW1CB7b93PHIbQ5t8Aoj/dCqNWQBDBbyUXGy2zFbhEcJBVcLeBpy3w8VEjzNTfRC6cVwASuHRP0aLBIPNjQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/mysql": "2.15.19",
-        "tslib": "^2.3.1"
+        "@types/mysql": "2.15.22"
       },
       "engines": {
         "node": ">=14"
@@ -670,13 +648,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.34.0.tgz",
-      "integrity": "sha512-wEJ9BcZTT/60a69V5GS/XlQx+JyoOKKYYR/kdZ2p/XY/UI+kELPSWiLZAR00YLYi33g0zVZlKG3gfHU1KFn5sQ==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.34.2.tgz",
+      "integrity": "sha512-Ac/KAHHtTz087P7I6JapBs+ofNOM+RPTDGwSe1ddnTj0xTAO0F6ITmRC1firnMdzDidI/wI+vmgnWclCB81xKQ==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/sql-common": "^0.40.0"
       },
       "engines": {
         "node": ">=14"
@@ -686,13 +664,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.33.0.tgz",
-      "integrity": "sha512-/c1nipi2XLt2TQlFpKNof44o99H7BmdOWiZBAdIATJpvOKPbn+Ggt4OQQdtmxFyzMX13dTxgtpQ5RX2Orvxz2Q==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.33.2.tgz",
+      "integrity": "sha512-jrX/355K+myc5V/EQFouqQzBfy5qj+SyVMHIKqVymOx/zWFCvz1p9ChNiPOKzl2il3o/P/aOqBUN/qnRaGowlw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -702,13 +679,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-net": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.32.0.tgz",
-      "integrity": "sha512-fIgmkTpkdDXlRKUC4X2SdpJJof+KCA7feiBlLXHJ6xcaqBWG/6mt25A1FTyaJiXRWPhk+faGhtMxT0WX2AD3kQ==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-net/-/instrumentation-net-0.32.2.tgz",
+      "integrity": "sha512-dkm5tZ2NP4Pn3LLs8IfizEQfFBJ7qrqvwoHQA20Z4ZjjjfrPd1aHANCYGs0axh/VBT0IACdX6IZZq/0Lb3Ocfw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -718,17 +694,16 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.36.0.tgz",
-      "integrity": "sha512-S9RmzTILWTl7AVfdp/e8lWQTlpwrpoPbpxAfEJ1ENzTlPMmdw0jWPAQTgrTLQa6cpzhiypDHts3g2b6hc1zFYQ==",
+      "version": "0.36.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.36.2.tgz",
+      "integrity": "sha512-KUjI8OGi7kicml2Sd/PR/M8otZoZEdPArMfhznS6OQKit+RxFo0p5x6RVeka/cLQlmoc3eeGBizDeZetssbHgw==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
         "@opentelemetry/sql-common": "^0.40.0",
         "@types/pg": "8.6.1",
-        "@types/pg-pool": "2.0.3",
-        "tslib": "^2.3.1"
+        "@types/pg-pool": "2.0.4"
       },
       "engines": {
         "node": ">=14"
@@ -738,12 +713,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-pino": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.34.0.tgz",
-      "integrity": "sha512-UtoVJG1gVit5Bksy0ccwtmJm9a39WDW4tMEAh0Spk31burJuEKKT09CslSQ3zmkoHj91iLWi5O5A94dIUVIXsg==",
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.34.2.tgz",
+      "integrity": "sha512-gGGeM2sRSulAtV2nAPMrRBm+nenyrKO3kyrORN+q2V4S8hx+6yze35+QQkU5uWk6N5/s5Y9bxqPcaNUt3jwprw==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0"
       },
       "engines": {
         "node": ">=14"
@@ -753,14 +727,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.0.tgz",
-      "integrity": "sha512-WXUjuTtDbV9e27xDtdi9ObjGeJnD8YI2FSb7Bu7yqrqU2c/AUDjUbLAtjxG5otfaRZbLEP57KrjHu5N5V5NzNg==",
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.35.2.tgz",
+      "integrity": "sha512-KBwVMsoiMc2kAffnmG64rJDMEbmK3VT991s7kedipJsBT9jrcx4tXT/fdIwFk+helawXHbiI0ILlxzA8dVYz3g==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/redis-common": "^0.36.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/redis-common": "^0.36.1",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -770,14 +743,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.35.0.tgz",
-      "integrity": "sha512-jCtYP3Cu3PcWzETFzdMn3iET1M9cXYihvwsSECq3bMKLUewY+Acc5jCycJyvnO/yZbEF2cDQS3m3UAdAVlG8Pw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.35.3.tgz",
+      "integrity": "sha512-fWMqJpEGLcE1Z76CTwhZPaFU7EGBZ/pNFKCLdHALddvud/9AxKbxLIn73QGh7sLU8MwhCBkTbuipj5UAy8g8TA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/redis-common": "^0.36.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/redis-common": "^0.36.1",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -787,14 +759,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-restify": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.33.0.tgz",
-      "integrity": "sha512-evDjcF6M9G+KH/GCjtUx9Vnm/CBZ9CBfmm/RP6Aeo20y6Kset1ZEoPK79JT7JK1sCPqViBPoj4qnFePz9/20lg==",
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-restify/-/instrumentation-restify-0.34.1.tgz",
+      "integrity": "sha512-lQwEieqPAnpKcNtINzsApmtj9Odvhu6bW5fZvSldSF2pzLOUb5Z9ZDjPnYlZyoWpwqlL8FLc9/LJ1BD4lSaGdA==",
       "dependencies": {
         "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -804,13 +775,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-router": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.33.0.tgz",
-      "integrity": "sha512-Dn/ARu14ePjtx0ejRJYvExt6y1wBchkAICv8JYOXRgNXWvFWBGTuucRc1Hwqk9YI8N4DYz1BVKe1sgJ3kBel6w==",
+      "version": "0.33.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-router/-/instrumentation-router-0.33.2.tgz",
+      "integrity": "sha512-GNQMLkz24vc0ND/Su3/ytyAfVPtBYnbLbM2dscj8h3VHebUZPWcOGk/M6wsqDCpEbP5xUA56afEkWsbGzWtMxA==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0",
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -820,14 +790,13 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.6.0.tgz",
-      "integrity": "sha512-dXTDFriaHOdL5X6MKNc4pno7GKJnatuNfvvXtzVHJY0+HAdc6c78PpnmFFAP8Uvoqp/eBsxYLd/fppl2HtxTrQ==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.6.2.tgz",
+      "integrity": "sha512-8/WwifQNuB/1bRWyqSCJPow/Gd6EubFpKbZJgOEIL1jk0Lk/ikpjI5zxqWbLIT2pUOi0Ihwvu5sTqgdY4oPz9Q==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
+        "@opentelemetry/instrumentation": "^0.44.0",
         "@opentelemetry/semantic-conventions": "^1.0.0",
-        "@types/tedious": "^4.0.6",
-        "tslib": "^2.3.1"
+        "@types/tedious": "^4.0.10"
       },
       "engines": {
         "node": ">=14"
@@ -837,12 +806,11 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-winston": {
-      "version": "0.32.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.32.0.tgz",
-      "integrity": "sha512-Pf+tsLmccH/RrUXPiirPj7GhADP1X+21C5lOaYegpyHZgWGLvjCx7W/c89wQSol7DertSUKMB1iixQpUmVqDdQ==",
+      "version": "0.32.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.32.2.tgz",
+      "integrity": "sha512-6+BMhSWaGxgezwOUuMH389V16fMgwFNmXAwh8zk0mjYHmWpyLzoJ+QV8AQ9WZFBQQnkpbbxfiFdiyO+NCvwBCg==",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.41.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/instrumentation": "^0.44.0"
       },
       "engines": {
         "node": ">=14"
@@ -852,11 +820,11 @@
       }
     },
     "node_modules/@opentelemetry/otlp-exporter-base": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.41.2.tgz",
-      "integrity": "sha512-pfwa6d+Dax3itZcGWiA0AoXeVaCuZbbqUTsCtOysd2re8C2PWXNxDONUfBWsn+KgxAdi+ljwTjJGiaVLDaIEvQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.44.0.tgz",
+      "integrity": "sha512-DKQqRrfVMe96aSLZiCgIesLcMLfnWH8d4bTpLB1JbU+SAQJ7nVCAfS9U36mjFCVhvNDD7gwfCNrxqFMCHq6FUw==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2"
+        "@opentelemetry/core": "1.17.1"
       },
       "engines": {
         "node": ">=14"
@@ -866,13 +834,13 @@
       }
     },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.41.2.tgz",
-      "integrity": "sha512-OErK8dYjXG01XIMIpmOV2SzL9ctkZ0Nyhf2UumICOAKtgLvR5dG1JMlsNVp8Jn0RzpsKc6Urv7JpP69wzRXN+A==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.44.0.tgz",
+      "integrity": "sha512-RsYW2+ikNDDXM9rY4gCA3lJOu53o4CzCsUJ9DV6r78k/Y0ckWw2GM7R4I6yOmMe4jilxEaHorI3oTJFLD8KYug==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.1",
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/otlp-exporter-base": "0.44.0",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -883,12 +851,12 @@
       }
     },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.41.2.tgz",
-      "integrity": "sha512-BxmEMiP6tHiFroe5/dTt9BsxCci7BTLtF7A6d4DKHLiLweWWZxQ9l7hON7qt/IhpKrQcAFD1OzZ1Gq2ZkNzhCw==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.44.0.tgz",
+      "integrity": "sha512-vgQvWEkXNk8X4BW93+j054TZBVs1ryguXQjeoLeHV/dzopdGuAypI0xC5OtSr+eRftuyPqPl2DVp4tjRq4z4dw==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/otlp-exporter-base": "0.41.2",
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/otlp-exporter-base": "0.44.0",
         "protobufjs": "^7.2.3"
       },
       "engines": {
@@ -899,31 +867,28 @@
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.41.2.tgz",
-      "integrity": "sha512-jJbPwB0tNu2v+Xi0c/v/R3YBLJKLonw1p+v3RVjT2VfzeUyzSp/tBeVdY7RZtL6dzZpA9XSmp8UEfWIFQo33yA==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.44.0.tgz",
+      "integrity": "sha512-1/KC+aHM1oGEsXyNy7QoxpvErxGdzt26bg9VHyNb4TDILkUFdwrnywnxPc6lXZ6h/8T8Mt718UWOKjNHC514kQ==",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.41.2",
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/sdk-logs": "0.41.2",
-        "@opentelemetry/sdk-metrics": "1.15.2",
-        "@opentelemetry/sdk-trace-base": "1.15.2"
+        "@opentelemetry/api-logs": "0.44.0",
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/sdk-logs": "0.44.0",
+        "@opentelemetry/sdk-metrics": "1.17.1",
+        "@opentelemetry/sdk-trace-base": "1.17.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+        "@opentelemetry/api": ">=1.3.0 <1.7.0"
       }
     },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.0.tgz",
-      "integrity": "sha512-gQ90Ry0aIcnnEckFCJlq/TAXnNYlH/Ff9qMQFCMI9oni3J7futG2k4SdrR3fS6D4cH2XwbenWxypt85cBaOv9A==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
+      "version": "0.30.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.2.tgz",
+      "integrity": "sha512-HMn33DQbehFvPW7PBzIajkRuoCGaSaa/vb8IyaXtRsX4aY8K9XqOiRwunN4bPo7rnh+KnRdKx0tO0In1zvdQ4w==",
       "engines": {
         "node": ">=14"
       },
@@ -932,12 +897,11 @@
       }
     },
     "node_modules/@opentelemetry/propagator-aws-xray": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.3.0.tgz",
-      "integrity": "sha512-0DrsBY/Fy12J+0wTxNOui2eunO5SIrSzf+k3kNeIh2EhPr8Y9Pd1XwOtRm5vooly0W+Oxkzk5U2vpz4dKQOBqQ==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.3.1.tgz",
+      "integrity": "sha512-6fDMzFlt5r6VWv7MUd0eOpglXPFqykW8CnOuUxJ1VZyLy6mV1bzBlzpsqEmhx1bjvZYvH93vhGkQZqrm95mlrQ==",
       "dependencies": {
-        "@opentelemetry/core": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/core": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -947,53 +911,49 @@
       }
     },
     "node_modules/@opentelemetry/propagator-b3": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.15.2.tgz",
-      "integrity": "sha512-ZSrL3DpMEDsjD8dPt9Ze3ue53nEXJt512KyxXlLgLWnSNbe1mrWaXWkh7OLDoVJh9LqFw+tlvAhDVt/x3DaFGg==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.17.1.tgz",
+      "integrity": "sha512-XEbXYb81AM3ayJLlbJqITPIgKBQCuby45ZHiB9mchnmQOffh6ZJOmXONdtZAV7TWzmzwvAd28vGSUk57Aw/5ZA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2"
+        "@opentelemetry/core": "1.17.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
       }
     },
     "node_modules/@opentelemetry/propagator-jaeger": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.15.2.tgz",
-      "integrity": "sha512-6m1yu7PVDIRz6BwA36lacfBZJCfAEHKgu+kSyukNwVdVjsTNeyD9xNPQnkl0WN7Rvhk8/yWJ83tLPEyGhk1wCQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.17.1.tgz",
+      "integrity": "sha512-p+P4lf2pbqd3YMfZO15QCGsDwR2m1ke2q5+dq6YBLa/q0qiC2eq4cD/qhYBBed5/X4PtdamaVGHGsp+u3GXHDA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2"
+        "@opentelemetry/core": "1.17.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
       }
     },
     "node_modules/@opentelemetry/redis-common": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.0.tgz",
-      "integrity": "sha512-rTKuBszerwzKm0uBmffJ8j47+5YBGu6HGUWnez5gev2B4by8TKkY37E/QMq7/3KRL9NkZ08VJCtl3piCCFW30g==",
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
+      "version": "0.36.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.1.tgz",
+      "integrity": "sha512-YjfNEr7DK1Ymc5H0bzhmqVvMcCs+PUEUerzrpTFdHfZxj3HpnnjZTIFKx/gxiL/sajQ8dxycjlreoYTVYKBXlw==",
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/resource-detector-aws": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.0.tgz",
-      "integrity": "sha512-fF1cMnR2ObMThJVkF4nUkTmmIbzMkrKs3ibEALs6sD3b6VqCZ8NafnX/GS+VpmguVevyGqFr/mLSdehNkm9ABg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-aws/-/resource-detector-aws-1.3.2.tgz",
+      "integrity": "sha512-RaBOD3mV69ukI43FZwrnOywAJe7M4405/dqdFRHv65rDLmYMBEUOLdrhqDk8uKJwaHAob2jyDBDCv48RnTZi5g==",
       "dependencies": {
         "@opentelemetry/core": "^1.0.0",
         "@opentelemetry/resources": "^1.0.0",
-        "@opentelemetry/semantic-conventions": "^1.0.0",
-        "tslib": "^2.3.1"
+        "@opentelemetry/semantic-conventions": "^1.0.0"
       },
       "engines": {
         "node": ">=14"
@@ -1003,91 +963,91 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.15.2.tgz",
-      "integrity": "sha512-xmMRLenT9CXmm5HMbzpZ1hWhaUowQf8UB4jMjFlAxx1QzQcsD3KFNAVX/CAWzFPtllTyTplrA4JrQ7sCH3qmYw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.17.1.tgz",
+      "integrity": "sha512-M2e5emqg5I7qRKqlzKx0ROkcPyF8PbcSaWEdsm72od9txP7Z/Pl8PDYOyu80xWvbHAWk5mDxOF6v3vNdifzclA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/semantic-conventions": "1.15.2"
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/semantic-conventions": "1.17.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
       }
     },
     "node_modules/@opentelemetry/sdk-logs": {
-      "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.41.2.tgz",
-      "integrity": "sha512-smqKIw0tTW15waj7BAPHFomii5c3aHnSE4LQYTszGoK5P9nZs8tEAIpu15UBxi3aG31ZfsLmm4EUQkjckdlFrw==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.44.0.tgz",
+      "integrity": "sha512-UN3ofh9Jj54gIgrSXNRWAoaH6iPvrrjed5YAtqO9cW65U+5QPzk1Rv95vjAcY9VTrmMWvuqgEK1CYObG6Hu4OQ==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/resources": "1.15.2"
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/resources": "1.17.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.4.0 <1.5.0",
+        "@opentelemetry/api": ">=1.4.0 <1.7.0",
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
     "node_modules/@opentelemetry/sdk-metrics": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.15.2.tgz",
-      "integrity": "sha512-9aIlcX8GnhcsAHW/Wl8bzk4ZnWTpNlLtud+fxUfBtFATu6OZ6TrGrF4JkT9EVrnoxwtPIDtjHdEsSjOqisY/iA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.17.1.tgz",
+      "integrity": "sha512-eHdpsMCKhKhwznxvEfls8Wv3y4ZBWkkXlD3m7vtHIiWBqsMHspWSfie1s07mM45i/bBCf6YBMgz17FUxIXwmZA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/resources": "1.15.2",
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/resources": "1.17.1",
         "lodash.merge": "^4.6.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.3.0 <1.5.0"
+        "@opentelemetry/api": ">=1.3.0 <1.7.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.15.2.tgz",
-      "integrity": "sha512-BEaxGZbWtvnSPchV98qqqqa96AOcb41pjgvhfzDij10tkBhIu9m0Jd6tZ1tJB5ZHfHbTffqYVYE0AOGobec/EQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.17.1.tgz",
+      "integrity": "sha512-pfSJJSjZj5jkCJUQZicSpzN8Iz9UKMryPWikZRGObPnJo6cUSoKkjZh6BM3j+D47G4olMBN+YZKYqkFM1L6zNA==",
       "dependencies": {
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/semantic-conventions": "1.15.2"
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/semantic-conventions": "1.17.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.15.2.tgz",
-      "integrity": "sha512-5deakfKLCbPpKJRCE2GPI8LBE2LezyvR17y3t37ZI3sbaeogtyxmBaFV+slmG9fN8OaIT+EUsm1QAT1+z59gbQ==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-1.17.1.tgz",
+      "integrity": "sha512-J56DaG4cusjw5crpI7x9rv4bxDF27DtKYGxXJF56KIvopbNKpdck5ZWXBttEyqgAVPDwHMAXWDL1KchHzF0a3A==",
       "dependencies": {
-        "@opentelemetry/context-async-hooks": "1.15.2",
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/propagator-b3": "1.15.2",
-        "@opentelemetry/propagator-jaeger": "1.15.2",
-        "@opentelemetry/sdk-trace-base": "1.15.2",
-        "semver": "^7.5.1"
+        "@opentelemetry/context-async-hooks": "1.17.1",
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/propagator-b3": "1.17.1",
+        "@opentelemetry/propagator-jaeger": "1.17.1",
+        "@opentelemetry/sdk-trace-base": "1.17.1",
+        "semver": "^7.5.2"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.5.0"
+        "@opentelemetry/api": ">=1.0.0 <1.7.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.15.2.tgz",
-      "integrity": "sha512-CjbOKwk2s+3xPIMcd5UNYQzsf+v94RczbdNix9/kQh38WiQkM90sUOi3if8eyHFgiBjBjhwXrA7W3ydiSQP9mw==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.17.1.tgz",
+      "integrity": "sha512-xbR2U+2YjauIuo42qmE8XyJK6dYeRMLJuOlUP5SO4auET4VtOHOzgkRVOq+Ik18N+Xf3YPcqJs9dZMiDddz1eQ==",
       "engines": {
         "node": ">=14"
       }
@@ -1179,59 +1139,59 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@splunk/otel": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.4.2.tgz",
-      "integrity": "sha512-9P5rBhFZXZ8FH6Y7rp47GbYvK3WiJ8Mzm2BjMmQFLzu+zmqu0UH0lPAJR4jRTsaBXig2fkDtWP3PLVM6AbeilQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.5.0.tgz",
+      "integrity": "sha512-cdqkJaEsIMYJde0FKDbTkSgg9LJUFC9I2aQbulvSoI2WLZm4aTQSDk/gQBlFob64LszQQp6iCXXfZyd3czU7bw==",
       "hasInstallScript": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.8.19",
         "@grpc/proto-loader": "^0.7.8",
         "@opentelemetry/api": "^1.3.0",
-        "@opentelemetry/context-async-hooks": "1.15.2",
-        "@opentelemetry/core": "1.15.2",
-        "@opentelemetry/exporter-metrics-otlp-grpc": "0.41.2",
-        "@opentelemetry/exporter-metrics-otlp-proto": "0.41.2",
-        "@opentelemetry/exporter-trace-otlp-grpc": "0.41.2",
-        "@opentelemetry/exporter-trace-otlp-proto": "0.41.2",
-        "@opentelemetry/instrumentation": "0.41.2",
-        "@opentelemetry/instrumentation-amqplib": "0.33.0",
-        "@opentelemetry/instrumentation-aws-sdk": "0.35.0",
-        "@opentelemetry/instrumentation-bunyan": "0.32.0",
-        "@opentelemetry/instrumentation-cassandra-driver": "0.33.0",
-        "@opentelemetry/instrumentation-connect": "0.32.0",
-        "@opentelemetry/instrumentation-dataloader": "0.5.0",
-        "@opentelemetry/instrumentation-dns": "0.32.0",
-        "@opentelemetry/instrumentation-express": "0.33.0",
-        "@opentelemetry/instrumentation-fastify": "0.32.0",
-        "@opentelemetry/instrumentation-generic-pool": "0.32.0",
-        "@opentelemetry/instrumentation-graphql": "0.35.0",
-        "@opentelemetry/instrumentation-grpc": "0.41.2",
-        "@opentelemetry/instrumentation-hapi": "0.32.0",
-        "@opentelemetry/instrumentation-http": "0.41.2",
-        "@opentelemetry/instrumentation-ioredis": "0.35.0",
-        "@opentelemetry/instrumentation-knex": "0.32.0",
-        "@opentelemetry/instrumentation-koa": "0.35.0",
-        "@opentelemetry/instrumentation-memcached": "0.32.0",
-        "@opentelemetry/instrumentation-mongodb": "0.36.0",
-        "@opentelemetry/instrumentation-mongoose": "0.33.0",
-        "@opentelemetry/instrumentation-mysql": "0.34.0",
-        "@opentelemetry/instrumentation-mysql2": "0.34.0",
-        "@opentelemetry/instrumentation-nestjs-core": "0.33.0",
-        "@opentelemetry/instrumentation-net": "0.32.0",
-        "@opentelemetry/instrumentation-pg": "0.36.0",
-        "@opentelemetry/instrumentation-pino": "0.34.0",
-        "@opentelemetry/instrumentation-redis": "0.35.0",
-        "@opentelemetry/instrumentation-redis-4": "0.35.0",
-        "@opentelemetry/instrumentation-restify": "0.33.0",
-        "@opentelemetry/instrumentation-router": "0.33.0",
-        "@opentelemetry/instrumentation-tedious": "0.6.0",
-        "@opentelemetry/instrumentation-winston": "0.32.0",
-        "@opentelemetry/propagator-b3": "1.15.2",
-        "@opentelemetry/resources": "1.15.2",
-        "@opentelemetry/sdk-metrics": "1.15.2",
-        "@opentelemetry/sdk-trace-base": "1.15.2",
-        "@opentelemetry/sdk-trace-node": "1.15.2",
-        "@opentelemetry/semantic-conventions": "1.15.2",
+        "@opentelemetry/context-async-hooks": "1.17.1",
+        "@opentelemetry/core": "1.17.1",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.44.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.44.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.44.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.44.0",
+        "@opentelemetry/instrumentation": "0.44.0",
+        "@opentelemetry/instrumentation-amqplib": "0.33.2",
+        "@opentelemetry/instrumentation-aws-sdk": "0.36.1",
+        "@opentelemetry/instrumentation-bunyan": "0.32.2",
+        "@opentelemetry/instrumentation-cassandra-driver": "0.33.2",
+        "@opentelemetry/instrumentation-connect": "0.32.2",
+        "@opentelemetry/instrumentation-dataloader": "0.5.2",
+        "@opentelemetry/instrumentation-dns": "0.32.3",
+        "@opentelemetry/instrumentation-express": "0.33.2",
+        "@opentelemetry/instrumentation-fastify": "0.32.3",
+        "@opentelemetry/instrumentation-generic-pool": "0.32.3",
+        "@opentelemetry/instrumentation-graphql": "0.35.2",
+        "@opentelemetry/instrumentation-grpc": "0.44.0",
+        "@opentelemetry/instrumentation-hapi": "0.33.1",
+        "@opentelemetry/instrumentation-http": "0.44.0",
+        "@opentelemetry/instrumentation-ioredis": "0.35.2",
+        "@opentelemetry/instrumentation-knex": "0.32.2",
+        "@opentelemetry/instrumentation-koa": "0.36.1",
+        "@opentelemetry/instrumentation-memcached": "0.32.2",
+        "@opentelemetry/instrumentation-mongodb": "0.37.1",
+        "@opentelemetry/instrumentation-mongoose": "0.33.2",
+        "@opentelemetry/instrumentation-mysql": "0.34.2",
+        "@opentelemetry/instrumentation-mysql2": "0.34.2",
+        "@opentelemetry/instrumentation-nestjs-core": "0.33.2",
+        "@opentelemetry/instrumentation-net": "0.32.2",
+        "@opentelemetry/instrumentation-pg": "0.36.2",
+        "@opentelemetry/instrumentation-pino": "0.34.2",
+        "@opentelemetry/instrumentation-redis": "0.35.2",
+        "@opentelemetry/instrumentation-redis-4": "0.35.3",
+        "@opentelemetry/instrumentation-restify": "0.34.1",
+        "@opentelemetry/instrumentation-router": "0.33.2",
+        "@opentelemetry/instrumentation-tedious": "0.6.2",
+        "@opentelemetry/instrumentation-winston": "0.32.2",
+        "@opentelemetry/propagator-b3": "1.17.1",
+        "@opentelemetry/resources": "1.17.1",
+        "@opentelemetry/sdk-metrics": "1.17.1",
+        "@opentelemetry/sdk-trace-base": "1.17.1",
+        "@opentelemetry/sdk-trace-node": "1.17.1",
+        "@opentelemetry/semantic-conventions": "1.17.1",
         "is-promise": "^4.0.0",
         "nan": "^2.17.0",
         "node-gyp-build": "^4.6.0",
@@ -1246,52 +1206,52 @@
       }
     },
     "node_modules/@types/accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.6.tgz",
+      "integrity": "sha512-6+qlUg57yfE9OO63wnsJXLeq9cG3gSHBBIxNMOjNrbDRlDnm/NaR7RctfYcVCPq+j7d+MwOxqVEludH5+FKrlg==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.81",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.81.tgz",
-      "integrity": "sha512-C1rFKGVZ8KwqhwBOYlpoybTSRtxu2433ea6JaO3amc6ubEe08yQoFsPa9aU9YqvX7ppeZ25CnCtC4AH9mhtxsQ=="
+      "version": "8.10.122",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.122.tgz",
+      "integrity": "sha512-vBkIh9AY22kVOCEKo5CJlyCgmSWvasC+SWUxL/x/vOwRobMpI/HG1xp/Ae3AqmSiZeLUbOhW0FCD3ZjqqUxmXw=="
     },
     "node_modules/@types/body-parser": {
-      "version": "1.19.2",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
-      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "version": "1.19.4",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.4.tgz",
+      "integrity": "sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==",
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
       }
     },
     "node_modules/@types/bunyan": {
-      "version": "1.8.7",
-      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.7.tgz",
-      "integrity": "sha512-jaNt6xX5poSmXuDAkQrSqx2zkR66OrdRDuVnU8ldvn3k/Ci/7Sf5nooKspQWimDnw337Bzt/yirqSThTjvrHkg==",
+      "version": "1.8.9",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.9.tgz",
+      "integrity": "sha512-ZqS9JGpBxVOvsawzmVt30sP++gSQMTejCkIAQ3VdadOcRE8izTyW66hufvwLeH+YEGP6Js2AW7Gz+RMyvrEbmw==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.35",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
-      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/content-disposition": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz",
-      "integrity": "sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA=="
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.7.tgz",
+      "integrity": "sha512-V9/5u21RHFR1zfdm3rQ6pJUKV+zSSVQt+yq16i1YhdivVzWgPEoKedc3GdT8aFjsqQbakdxuy3FnEdePUQOamQ=="
     },
     "node_modules/@types/cookies": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.7.tgz",
-      "integrity": "sha512-h7BcvPUogWbKCzBR2lY4oqaZbO3jXZksexYJVFvkrFeLgbZjQkU4x8pRq6eg2MHXQhY0McQdqmmsxRWlVAHooA==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.7.9.tgz",
+      "integrity": "sha512-SrGYvhKohd/WSOII0WpflC73RgdJhQoqpwq9q+n/qugNGiDSGYXfHy3QvB4+X+J/gYe27j2fSRnK4B+1A3nvsw==",
       "dependencies": {
         "@types/connect": "*",
         "@types/express": "*",
@@ -1300,20 +1260,20 @@
       }
     },
     "node_modules/@types/express": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
-      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
+      "version": "4.17.18",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
+      "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
       "dependencies": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
+        "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.35",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz",
-      "integrity": "sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==",
+      "version": "4.17.39",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
+      "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1321,24 +1281,15 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/generic-pool": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@types/generic-pool/-/generic-pool-3.8.1.tgz",
-      "integrity": "sha512-eaMAbZS0EfKvaP5PUZ/Cdf5uJBO2t6T3RdvQTKuMqUwGhNpCnPAsKWEMyV+mCeCQG3UiHrtgdzni8X6DmhxRaQ==",
-      "deprecated": "This is a stub types definition. generic-pool provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "generic-pool": "*"
-      }
-    },
     "node_modules/@types/hapi__catbox": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.4.tgz",
-      "integrity": "sha512-A6ivRrXD5glmnJna1UAGw87QNZRp/vdFO9U4GS+WhOMWzHnw+oTGkMvg0g6y1930CbeheGOCm7A1qHsqH7AXqg=="
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/@types/hapi__catbox/-/hapi__catbox-10.2.5.tgz",
+      "integrity": "sha512-vomIMP6dUDSbiasbPglH5LJvnnl8jFmRTjPgPl4l9Vi1L9fto3VXJQZtl8LzyIQUUoocyT5bmvWeYWsVgxAHQg=="
     },
     "node_modules/@types/hapi__hapi": {
-      "version": "20.0.9",
-      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.9.tgz",
-      "integrity": "sha512-fGpKScknCKZityRXdZgpCLGbm41R1ppFgnKHerfZlqOOlCX/jI129S6ghgBqkqCE8m9A0CIu1h7Ch04lD9KOoA==",
+      "version": "20.0.13",
+      "resolved": "https://registry.npmjs.org/@types/hapi__hapi/-/hapi__hapi-20.0.13.tgz",
+      "integrity": "sha512-LP4IPfhIO5ZPVOrJo7H8c8Slc0WYTFAUNQX1U0LBPKyXioXhH5H2TawIgxKujIyOhbwoBbpvOsBf6o5+ToJIrQ==",
       "dependencies": {
         "@hapi/boom": "^9.0.0",
         "@hapi/iron": "^6.0.0",
@@ -1359,22 +1310,22 @@
       }
     },
     "node_modules/@types/hapi__shot": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.2.tgz",
-      "integrity": "sha512-8wWgLVP1TeGqgzZtCdt+F+k15DWQvLG1Yv6ZzPfb3D5WIo5/S+GGKtJBVo2uNEcqabP5Ifc71QnJTDnTmw1axA==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/hapi__shot/-/hapi__shot-4.1.4.tgz",
+      "integrity": "sha512-AhEirOGy2ajtdV9WE/JqPkGeCH8lpgcSEQxn0ZNJkTvxkOv5DfZEXGit3l5J9P1VoQFAAHGNLVGWI5IWCiQf9A==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/http-assert": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz",
-      "integrity": "sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA=="
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.4.tgz",
+      "integrity": "sha512-/6M9aaVk+avzCsrv1lt39AlFw4faCNI6aGll91Rxj38ZE5JI8AxApyQIRy+i1McjiJiuQ0sfuoMLxqq374ZIbA=="
     },
     "node_modules/@types/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.3.tgz",
+      "integrity": "sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA=="
     },
     "node_modules/@types/ioredis4": {
       "name": "@types/ioredis",
@@ -1386,14 +1337,14 @@
       }
     },
     "node_modules/@types/keygrip": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha512-GJhpTepz2udxGexqos8wgaBx4I/zWIDPh/KOGEwAqtuGDkOUJu5eFvwmdBX4AmB8Odsr+9pHCQqiAqDL/yKMKw=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.4.tgz",
+      "integrity": "sha512-/tjWYD8StMrINelsrHNmpXceo9s3/Y22AzePH1qCvXIgmz/aQp2YFFr6HqhNQVIOdcvaVyp5GS+yjHGuF7Rwsg=="
     },
     "node_modules/@types/koa": {
-      "version": "2.13.6",
-      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.6.tgz",
-      "integrity": "sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==",
+      "version": "2.13.9",
+      "resolved": "https://registry.npmjs.org/@types/koa/-/koa-2.13.9.tgz",
+      "integrity": "sha512-tPX3cN1dGrMn+sjCDEiQqXH2AqlPoPd594S/8zxwUm/ZbPsQXKqHPUypr2gjCPhHUc+nDJLduhh5lXI/1olnGQ==",
       "dependencies": {
         "@types/accepts": "*",
         "@types/content-disposition": "*",
@@ -1406,56 +1357,54 @@
       }
     },
     "node_modules/@types/koa__router": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.7.tgz",
-      "integrity": "sha512-OB3Ax75nmTP+WR9AgdzA42DI7YmBtiNKN2g1Wxl+d5Dyek9SWt740t+ukwXSmv/jMBCUPyV3YEI93vZHgdP7UQ==",
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-12.0.1.tgz",
+      "integrity": "sha512-uqV+v6pCsfLZwK+Ar6XavKSZ6Cbsgw12bCEX9L0IKHj81LTWXcrayxJWkLtez5vOMQlq+ax+lZcuCyh9CgxYGw==",
       "dependencies": {
         "@types/koa": "*"
       }
     },
     "node_modules/@types/koa-compose": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.5.tgz",
-      "integrity": "sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@types/koa-compose/-/koa-compose-3.2.7.tgz",
+      "integrity": "sha512-smtvSL/oLICPuenxy73OmxKGh42VVfn2o2eutReH1yjij0LmxADBpGcAJbp4N+yJjPapPN7jAX9p7Ue0JMQ/Ag==",
       "dependencies": {
         "@types/koa": "*"
       }
     },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
-    },
     "node_modules/@types/memcached": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.7.tgz",
-      "integrity": "sha512-ImJbz1i8pl+OnyhYdIDnHe8jAuM8TOwM/7VsciqhYX3IL0jPPUToAtVxklfcWFGYckahEYZxhd9FS0z3MM1dpA==",
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/@types/memcached/-/memcached-2.2.9.tgz",
+      "integrity": "sha512-3WVct68tDdjQ0lkOim8PcULZCoPtpYeh41J6IoAV/cTjh0LXD2DThDGLaWRPLtmLoDQ6sO390hgfrcKwYUD52A==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/mime": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
-      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw=="
     },
     "node_modules/@types/mime-db": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.1.tgz",
-      "integrity": "sha512-kGZJY+R+WnR5Rk+RPHUMERtb2qBRViIHCBdtUrY+NmwuGb8pQdfTqQiCKPrxpdoycl8KWm2DLdkpoSdt479XoQ=="
+      "version": "1.43.3",
+      "resolved": "https://registry.npmjs.org/@types/mime-db/-/mime-db-1.43.3.tgz",
+      "integrity": "sha512-vg0UsF1p1Qi/8iCARoie7F/Ng92zo7tQlL+sqE15GonkKVl55n/0vB6jSbrYTgDO0PSx9pKfGG1iZg9gJum3wA=="
     },
     "node_modules/@types/mysql": {
-      "version": "2.15.19",
-      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.19.tgz",
-      "integrity": "sha512-wSRg2QZv14CWcZXkgdvHbbV2ACufNy5EgI8mBBxnJIptchv7DBy/h53VMa2jDhyo0C9MO4iowE6z9vF8Ja1DkQ==",
+      "version": "2.15.22",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.22.tgz",
+      "integrity": "sha512-wK1pzsJVVAjYCSZWQoWHziQZbNggXFDUEIGf54g4ZM/ERuP86uGdWeKZWMYlqTPMZfHJJvLPyogXGvCOg87yLQ==",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
-      "version": "20.4.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.9.tgz",
-      "integrity": "sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ=="
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.9.tgz",
+      "integrity": "sha512-UzykFsT3FhHb1h7yD4CA4YhBHq545JC0YnEz41xkipN88eKQtL6rSgocL5tbAP6Ola9Izm/Aw4Ora8He4x0BHg==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/pg": {
       "version": "8.6.1",
@@ -1468,36 +1417,36 @@
       }
     },
     "node_modules/@types/pg-pool": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.3.tgz",
-      "integrity": "sha512-fwK5WtG42Yb5RxAwxm3Cc2dJ39FlgcaNiXKvtTLAwtCn642X7dgel+w1+cLWwpSOFImR3YjsZtbkfjxbHtFAeg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.4.tgz",
+      "integrity": "sha512-qZAvkv1K3QbmHHFYSNRYPkRjOWRLBYrL4B9c+wG0GSVGBw0NtJwPcgx/DSddeDJvRGMHCEQ4VMEVfuJ/0gZ3XQ==",
       "dependencies": {
         "@types/pg": "*"
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+      "version": "6.9.9",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.9.tgz",
+      "integrity": "sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg=="
     },
     "node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
-      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.6.tgz",
+      "integrity": "sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA=="
     },
     "node_modules/@types/send": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
-      "integrity": "sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==",
+      "version": "0.17.3",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.3.tgz",
+      "integrity": "sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==",
       "dependencies": {
         "@types/mime": "^1",
         "@types/node": "*"
       }
     },
     "node_modules/@types/serve-static": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.2.tgz",
-      "integrity": "sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.4.tgz",
+      "integrity": "sha512-aqqNfs1XTF0HDrFdlY//+SGUxmdSUbjeRXb5iaZc3x0/vMbYmdw9qvOgHWOyyLFxSSRnUuP5+724zBgfw8/WAw==",
       "dependencies": {
         "@types/http-errors": "*",
         "@types/mime": "*",
@@ -1505,19 +1454,19 @@
       }
     },
     "node_modules/@types/shimmer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.2.tgz",
-      "integrity": "sha512-dKkr1bTxbEsFlh2ARpKzcaAmsYixqt9UyCdoEZk8rHyE4iQYcDCyvSjDSf7JUWJHlJiTtbIoQjxKh6ViywqDAg=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.0.4.tgz",
+      "integrity": "sha512-hsughtxFsdJ9+Gxd/qH8zHE+KT6YEAxx9hJLoSXhxTBKHMQ2NMhN23fRJ75M9RRn2hDMNn13H3gS1EktA9VgDA=="
     },
     "node_modules/@types/signalfx": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@types/signalfx/-/signalfx-7.4.1.tgz",
-      "integrity": "sha512-Beti7SiFPEktPrcwhwkIzyftkbJNomvl54wu3LaSephb1gaf2coroiQ/jRSnp9xnAMsVVAn7l4e59A4Y3OJB9A=="
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/signalfx/-/signalfx-7.4.3.tgz",
+      "integrity": "sha512-W4lATW39+x7bKSb4pHaJ4dRKwCN5UTPmTTmoU9wk42OBGL82gixcHN1eAIEeqclu3hGa2BOp9OcpbAkH93hpOQ=="
     },
     "node_modules/@types/tedious": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.9.tgz",
-      "integrity": "sha512-ipwFvfy9b2m0gjHsIX0D6NAAwGCKokzf5zJqUZHUGt+7uWVlBIy6n2eyMgiKQ8ChLFVxic/zwQUhjLYNzbHDRA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.13.tgz",
+      "integrity": "sha512-eCADRqah0uHMUNVHJ/0Yz4drscJ5tZ+IQ/i+nDs7/nR8R6RqLhJaplklvMe3EsMraxOWmp4mTqYi0Xo6ik1DpQ==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1627,16 +1576,11 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "node_modules/generic-pool": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
-      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
-      "engines": {
-        "node": ">= 4"
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -1647,15 +1591,15 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
       "dependencies": {
-        "function-bind": "^1.1.1"
+        "function-bind": "^1.1.2"
       },
       "engines": {
-        "node": ">= 0.4.0"
+        "node": ">= 0.4"
       }
     },
     "node_modules/import-in-the-middle": {
@@ -1670,11 +1614,11 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1694,9 +1638,9 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/joi": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
+      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -1716,9 +1660,9 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "node_modules/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1742,14 +1686,14 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "node_modules/node-gyp-build": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
-      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.1.tgz",
+      "integrity": "sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -1825,9 +1769,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.4.tgz",
-      "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -1846,11 +1790,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/protobufjs/node_modules/long": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
-      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -1874,9 +1813,9 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
-      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
       "dependencies": {
         "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
@@ -1943,11 +1882,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA=="
-    },
     "node_modules/typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
@@ -1960,6 +1894,11 @@
       "engines": {
         "node": ">=4.2.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -28,10 +28,10 @@
     "typescript": "4.9"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation-aws-lambda": "0.36.0",
-    "@opentelemetry/resource-detector-aws": "1.3.0",
-    "@opentelemetry/sdk-trace-node": "1.15.2",
-    "@splunk/otel": "2.4.2",
-    "@types/signalfx": "7.4.1"
+    "@opentelemetry/instrumentation-aws-lambda": "0.37.1",
+    "@opentelemetry/resource-detector-aws": "1.3.2",
+    "@opentelemetry/sdk-trace-node": "1.17.1",
+    "@splunk/otel": "2.5.0",
+    "@types/signalfx": "7.4.3"
   }
 }


### PR DESCRIPTION
- Updated node to splunk-otel 2.5.0
- Updated upstream otel-lambda to latest
- Updated java dependencies, including otel-java sdk 1.30
