### PR TITLE
Jan2024 updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## [Unreleased]
 
-- Remove ruby support
+## 0.8.0
+
+- Remove ruby support.  Please use manual or upstream ruby instrumentation.
+- Update upstream otel-lambda to latest
+- Update otel-java dependencies to 2.0.0
+- Update splunk-otel-python to 1.17.0
+- Update splunk-otel-js to 2.6.1
 
 ## 0.7.4
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -8,8 +8,8 @@ description = "Splunk distribution of OpenTelemetry Lambda"
 
 ext {
     versions = [
-            opentelemetry: '1.32.0',
-            opentelemetryalpha: '1.32.0-alpha'
+            opentelemetry: '2.0.0',
+            opentelemetryalpha: '2.0.0-alpha'
     ]
 }
 

--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -13,7 +13,7 @@
         "@opentelemetry/instrumentation-aws-lambda": "0.37.3",
         "@opentelemetry/resource-detector-aws": "1.3.4",
         "@opentelemetry/sdk-trace-node": "1.18.1",
-        "@splunk/otel": "2.6.0",
+        "@splunk/otel": "2.6.1",
         "@types/signalfx": "7.4.3"
       },
       "devDependencies": {
@@ -24,9 +24,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.13",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.13.tgz",
-      "integrity": "sha512-OEZZu9v9AA+7/tghMDE8o5DAMD5THVnwSqDWuh7PPYO5287rTyqy0xEHT6/e4pbqSrhyLPdQFsam4TwFQVVIIw==",
+      "version": "1.9.14",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.14.tgz",
+      "integrity": "sha512-nOpuzZ2G3IuMFN+UPPpKrC6NsLmWsTqSsm66IRfnBt1D4pwTqE27lmbpcPM+l2Ua4gE7PfjRHI6uedAy7hoXUw==",
       "dependencies": {
         "@grpc/proto-loader": "^0.7.8",
         "@types/node": ">=12.12.47"
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@opentelemetry/api": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.6.0.tgz",
-      "integrity": "sha512-OWlrQAnWn9577PhVgqjUvMr1pg57Bc4jv0iL4w0PRuOSRvq67rvHW9Ie/dZVMvCzhSCB+UxhcY/PmCmFj33Q+g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.7.0.tgz",
+      "integrity": "sha512-AdY5wvN0P2vXBi3b29hxZgSFvdhdxPB9+f0B6s//P9Q8nibRWeA3cHm8UmLpio9ABigkVHJ5NMPk+Mz8VCCyrw==",
       "engines": {
         "node": ">=8.0.0"
       }
@@ -167,11 +167,11 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
-      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.21.0.tgz",
+      "integrity": "sha512-KP+OIweb3wYoP7qTYL/j5IpOlu52uxBv5M4+QhSmmUfLyTgu1OIS71msK3chFo1D6Y61BIH3wMiMYRCxJCQctA==",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -200,6 +200,43 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
       "version": "0.45.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.45.1.tgz",
@@ -216,6 +253,43 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
@@ -238,6 +312,43 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
       "version": "0.45.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.45.1.tgz",
@@ -257,6 +368,43 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
       "version": "0.45.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.45.1.tgz",
@@ -274,6 +422,43 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
@@ -499,6 +684,14 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
+    "node_modules/@opentelemetry/instrumentation-grpc/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation-hapi": {
       "version": "0.33.2",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.33.2.tgz",
@@ -531,6 +724,28 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
@@ -833,6 +1048,28 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
       "version": "0.45.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.45.1.tgz",
@@ -850,6 +1087,28 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/otlp-proto-exporter-base": {
       "version": "0.45.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-proto-exporter-base/-/otlp-proto-exporter-base-0.45.1.tgz",
@@ -864,6 +1123,28 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-proto-exporter-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/otlp-transformer": {
@@ -885,10 +1166,47 @@
         "@opentelemetry/api": ">=1.3.0 <1.8.0"
       }
     },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/propagation-utils": {
-      "version": "0.30.4",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.4.tgz",
-      "integrity": "sha512-drYvwfhdXZ6ax5xnpuEQ/0C0AaCcxXcf47wZFNIK4DZu2RJmGk24XUSGWg5XI9gMKBe5qwXWBh9aSlSLWdA/Ww==",
+      "version": "0.30.5",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.30.5.tgz",
+      "integrity": "sha512-9ENyx6ptmjyYzL7le3FXk/lJc3cFFTrh9Y/ubO9velQZ64BdjpF9kOMJN3Z8KLJFVt66HYoWy9xlWoSIfS/ICg==",
       "engines": {
         "node": ">=14"
       },
@@ -924,6 +1242,28 @@
         "@opentelemetry/api": ">=1.0.0 <1.8.0"
       }
     },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/propagator-jaeger": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-1.18.1.tgz",
@@ -936,6 +1276,28 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/redis-common": {
@@ -963,12 +1325,12 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
-      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.21.0.tgz",
+      "integrity": "sha512-1Z86FUxPKL6zWVy2LdhueEGl9AHDJcx+bvHStxomruz6Whd02mE3lNUMjVJ+FGRoktx/xYQcxccYb03DiUP6Yw==",
       "dependencies": {
-        "@opentelemetry/core": "1.18.1",
-        "@opentelemetry/semantic-conventions": "1.18.1"
+        "@opentelemetry/core": "1.21.0",
+        "@opentelemetry/semantic-conventions": "1.21.0"
       },
       "engines": {
         "node": ">=14"
@@ -993,6 +1355,43 @@
         "@opentelemetry/api-logs": ">=0.39.1"
       }
     },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/sdk-metrics": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.18.1.tgz",
@@ -1009,6 +1408,43 @@
         "@opentelemetry/api": ">=1.3.0 <1.8.0"
       }
     },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.18.1.tgz",
@@ -1023,6 +1459,43 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
@@ -1044,10 +1517,32 @@
         "@opentelemetry/api": ">=1.0.0 <1.8.0"
       }
     },
-    "node_modules/@opentelemetry/semantic-conventions": {
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node/node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
       "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.21.0.tgz",
+      "integrity": "sha512-lkC8kZYntxVKr7b8xmjCVUgE0a8xgDakPyDo9uSWavXPyYqLgYYGdEd2j8NxihRyb6UwpX3G/hFUF4/9q2V+/g==",
       "engines": {
         "node": ">=14"
       }
@@ -1139,9 +1634,9 @@
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
     "node_modules/@splunk/otel": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.6.0.tgz",
-      "integrity": "sha512-c4DljRVLwN03Ur0tc28z22WLprQhnQi/PTsXr88i3Ps2Prk52ApJ/EGkReJnC+oHjt5CU1A9tWmCN2F5AAXzTQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-2.6.1.tgz",
+      "integrity": "sha512-hBT23pSQp2HXYC99br9bQT6Qsdnz7KBchzUwXtvTf0wMjk6bYkute9/5a2PyrPxjQpYh90C+ccW0rvOMmnUtLw==",
       "hasInstallScript": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.8.19",
@@ -1195,7 +1690,7 @@
         "is-promise": "^4.0.0",
         "nan": "^2.18.0",
         "node-gyp-build": "^4.7.1",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.2.5",
         "semver": "^7.5.4"
       },
       "engines": {
@@ -1203,6 +1698,43 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/core": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.18.1.tgz",
+      "integrity": "sha512-kvnUqezHMhsQvdsnhnqTNfAJs3ox/isB0SVrM1dhVFw7SsB7TstuVa6fgWnN2GdPyilIFLUvvbTZoVRmx6eiRg==",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/resources": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.18.1.tgz",
+      "integrity": "sha512-JjbcQLYMttXcIabflLRuaw5oof5gToYV9fuXbcsoOeQ0BlbwUn6DAZi++PNsSz2jjPeASfDls10iaO/8BRIPRA==",
+      "dependencies": {
+        "@opentelemetry/core": "1.18.1",
+        "@opentelemetry/semantic-conventions": "1.18.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.8.0"
+      }
+    },
+    "node_modules/@splunk/otel/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.18.1.tgz",
+      "integrity": "sha512-+NLGHr6VZwcgE/2lw8zDIufOCGnzsA5CbQIMleXZTrgkBd0TanCX+MiDYJ1TOS4KL/Tqk0nFRxawnaYr6pkZkA==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/accepts": {
@@ -1271,9 +1803,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.41",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
-      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "version": "4.17.42",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.42.tgz",
+      "integrity": "sha512-ckM3jm2bf/MfB3+spLPWYPUH573plBFwpOhqQ2WottxYV85j1HQFlxmnTq57X1yHY9awZPig06hL/cLMgNWHIQ==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1399,9 +1931,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.10.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
-      "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
+      "version": "20.11.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.7.tgz",
+      "integrity": "sha512-GPmeN1C3XAyV5uybAf4cMLWT9fDWcmQhZVtMFu7OR32WjrqGG+Wnk2V1d0bmtUyE/Zy1QJ9BxyiTih9z8Oks8A==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1425,9 +1957,9 @@
       }
     },
     "node_modules/@types/qs": {
-      "version": "6.9.10",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
-      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw=="
+      "version": "6.9.11",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.11.tgz",
+      "integrity": "sha512-oGk0gmhnEJK4Yyk+oI7EfXsLayXatCWPHary1MtcmbAifkobT9cM9yutG/hZKIseOU0MqbIwQ/u2nn/Gb+ltuQ=="
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
@@ -1472,9 +2004,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1638,13 +2170,13 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/joi": {
-      "version": "17.11.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.11.0.tgz",
-      "integrity": "sha512-NgB+lZLNoqISVy1rZocE9PZI36bL/77ie924Ri43yEvi9GUUMPeyVIr8KdFTMUlby1p0PBYMk9spIxEUQYqrJQ==",
+      "version": "17.12.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.0.tgz",
+      "integrity": "sha512-HSLsmSmXz+PV9PYoi3p7cgIbj06WnEBNT28n+bbBNcPZXZFqCzzvGqpTBPujx/Z0nh1+KNQPDrNgdmQ8dq0qYw==",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.4",
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
@@ -1691,9 +2223,9 @@
       "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
     },
     "node_modules/node-gyp-build": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.7.1.tgz",
-      "integrity": "sha512-wTSrZ+8lsRRa3I3H8Xr65dLWSgCvY2l4AOnaeKdPA9TB/WYMPaTcrzf3rXvFoVvjKNVnu0CcWSx54qq9GKRUYg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -1769,9 +2301,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.2.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.6.tgz",
+      "integrity": "sha512-dgJaEDDL6x8ASUZ1YqWciTRrdOuYNzoOf27oHNfdyvKqHr5i0FV7FSLU+aIeFjyFgVxrpTOtQUi0BLLBymZaBw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -31,7 +31,7 @@
     "@opentelemetry/instrumentation-aws-lambda": "0.37.3",
     "@opentelemetry/resource-detector-aws": "1.3.4",
     "@opentelemetry/sdk-trace-node": "1.18.1",
-    "@splunk/otel": "2.6.0",
+    "@splunk/otel": "2.6.1",
     "@types/signalfx": "7.4.3"
   }
 }

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -8,11 +8,11 @@ echo "Modify dependencies and script for Splunk integration"
 pushd "$OTEL_PYTHON_DIR"
 
 cd "$SOURCES_DIR"
-sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.16.0/g' requirements.txt
-sed -i 's/^opentelemetry-exporter-otlp-proto-http.*/opentelemetry-exporter-otlp-proto-http==1.21.0/g' requirements.txt
+sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.17.0/g' requirements.txt
+sed -i 's/^opentelemetry-exporter-otlp-proto-http.*/opentelemetry-exporter-otlp-proto-http==1.22.0/g' requirements.txt
 # Even if this regex does nothing, leave these lines in to make later updates easier
-sed -i 's/0.42b0/0.42b0/g' requirements-nodeps.txt
-sed -i 's/0.42b0/0.42b0/g' requirements.txt
+sed -i 's/0.43b0/0.43b0/g' requirements-nodeps.txt
+sed -i 's/0.43b0/0.43b0/g' requirements.txt
 sed -i 's/^docker run --rm/docker run/g'  ../../build.sh
 sed -i 's/opentelemetry-instrument/splunk-py-trace/g'  otel-instrument
 echo "Modified python wrapper requirements:"


### PR DESCRIPTION
- Update upstream otel-lambda to latest
- Update otel-java dependencies to 2.0.0
- Update splunk-otel-python to 1.17.0
- Update splunk-otel-js to 2.6.1