### PR TITLE
Add nodejs to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/java"
     schedule:
       interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/nodejs"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Python is not necessary since there is no pip usage there