### PR TITLE
Update changelog  for 0.9.6 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+## 0.9.6
+- Upstream opentelemetry has deprecated OPENTELEMETRY_COLLECTOR_CONFIG_FILE and
+  renamed it to OPENTELEMETRY_COLLECTOR_CONFIG_URI.  Please adjust
+  your environments accordingly.
+
 ## 0.9.1
 - Re-enable python metrics exporting
 


### PR DESCRIPTION
Of particular note is the `OPENTELEMETRY_COLLECTOR_CONFIG_FILE`/`OPENTELEMETRY_COLLECTOR_CONFIG_URI` switch