### PR TITLE
Oct2024 updates 

### DIFF
--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -8,12 +8,12 @@ echo "Modify dependencies and script for Splunk integration"
 pushd "$OTEL_PYTHON_DIR"
 
 cd "$SOURCES_DIR"
-sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.20.0/g' requirements.txt
-sed -i 's/^opentelemetry-exporter-otlp-proto-http.*/opentelemetry-exporter-otlp-proto-http==1.26.0/g' requirements.txt
+sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==1.21.0/g' requirements.txt
+sed -i 's/^opentelemetry-exporter-otlp-proto-http.*/opentelemetry-exporter-otlp-proto-http==1.27.0/g' requirements.txt
 # Even if these regexes do nothing, leave these lines in to make later updates easier
-sed -i 's/0.47b0/0.47b0/g' nodeps-requirements.txt
-sed -i 's/0.47b0/0.47b0/g' requirements.txt
-sed -i 's/1.26.0/1.26.0/g' requirements.txt
+sed -i 's/0.48b0/0.48b0/g' nodeps-requirements.txt
+sed -i 's/0.48b0/0.48b0/g' requirements.txt
+sed -i 's/1.27.0/1.27.0/g' requirements.txt
 sed -i 's/^docker run --rm/docker run/g'  ../../build.sh
 sed -i 's/opentelemetry-instrument/splunk-py-trace/g'  otel-instrument
 # FIXME this recently broke and why aren't these a vendored part of pkg_resources anymore? perhaps we should remove the dependency on pkg_resources?


### PR DESCRIPTION
- Update upstream otel-lambda to latest
- Update splunk-otel-python to 1.21.0 and otel dependencies accordingly
- Fix direct lambda invocation propagation in node.js