### PR TITLE
Fix python 3.8 test by running build with 3.8 image

### DIFF
--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -26,7 +26,7 @@ cat requirements.txt
 cd ../..
 
 # FIXME upstream python version specification fix?
-sed -i '1iENV PIP_PYTHON_VERSION=3.8' otel/Dockerfile
+sed -i '6iENV PIP_PYTHON_VERSION=3.8' otel/Dockerfile
 echo "Modified Dockerfile:"
 cat otel/Dockerfile
 echo "----"

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -26,7 +26,7 @@ cat requirements.txt
 cd ../..
 
 # FIXME upstream python version specification fix?
-sed -i '6iENV PIP_PYTHON_VERSION=3.8' otel/Dockerfile
+sed -i 's/python3.*/python3.8/' otel/Dockerfile
 echo "Modified Dockerfile:"
 cat otel/Dockerfile
 echo "----"

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -25,6 +25,13 @@ echo "Modified python wrapper requirements:"
 cat requirements.txt
 cd ../..
 
+# FIXME upstream python version specification fix?
+sed -i '1iENV PIP_PYTHON_VERSION=3.8' otel/Dockerfile
+echo "Modified Dockerfile:"
+cat Dockerfile
+echo "----"
+
+
 echo "Building OTel Lambda python"
 rm -rf build
 ./build.sh

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -25,7 +25,8 @@ echo "Modified python wrapper requirements:"
 cat requirements.txt
 cd ../..
 
-# FIXME upstream python version specification fix?
+# FIXME no good way to specify python version requirement to pip; use 3.8 runtime/setuptools image
+# This block can be removed once python 3.8 reaches "no updates" aws deprecation status in March 2025
 sed -i 's/runtime=python3.*/runtime=python3.8/' otel/Dockerfile
 echo "Modified Dockerfile:"
 cat otel/Dockerfile

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -28,7 +28,7 @@ cd ../..
 # FIXME upstream python version specification fix?
 sed -i '1iENV PIP_PYTHON_VERSION=3.8' otel/Dockerfile
 echo "Modified Dockerfile:"
-cat Dockerfile
+cat otel/Dockerfile
 echo "----"
 
 

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -26,7 +26,7 @@ cat requirements.txt
 cd ../..
 
 # FIXME upstream python version specification fix?
-sed -i 's/python3.*/python3.8/' otel/Dockerfile
+sed -i 's/runtime=python3.*/runtime=python3.8/' otel/Dockerfile
 echo "Modified Dockerfile:"
 cat otel/Dockerfile
 echo "----"


### PR DESCRIPTION
An update to `pkg_resources` requires python 3.9 now, so use `setuptools` from a 3.8 image until 3.8 support can fully go away.