### PR TITLE
Node.js: upgrade to @splunk/otel 3.3.0, fix dependencies

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -10,11 +10,10 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation-aws-lambda": "0.53.0",
+        "@opentelemetry/instrumentation-aws-lambda": "0.50.3",
         "@opentelemetry/resource-detector-aws": "1.12.0",
         "@opentelemetry/sdk-trace-node": "1.30.1",
-        "@splunk/otel": "3.2.0",
-        "@types/signalfx": "7.4.5"
+        "@splunk/otel": "3.3.0"
       },
       "devDependencies": {
         "node-prune": "^1.0.2",
@@ -301,46 +300,17 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation-aws-lambda": {
-      "version": "0.53.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.53.0.tgz",
-      "integrity": "sha512-dZywDIc4t7o28eU9W4QMB+mNhRdH5/kVxVmxRtB46/diHg8Im6RFncuiCVJ1l9ig/RUtwR3dU9LX1huFBwxkPw==",
+      "version": "0.50.3",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-lambda/-/instrumentation-aws-lambda-0.50.3.tgz",
+      "integrity": "sha512-kotm/mRvSWUauudxcylc5YCDei+G/r+jnOH6q5S99aPLQ/Ms8D2yonMIxEJUILIPlthEmwLYxkw3ualWzMjm/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/instrumentation": "^0.57.1",
         "@opentelemetry/semantic-conventions": "^1.27.0",
         "@types/aws-lambda": "8.10.147"
       },
       "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-aws-lambda/node_modules/@opentelemetry/api-logs": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
-      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-aws-lambda/node_modules/@opentelemetry/instrumentation": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.202.0.tgz",
-      "integrity": "sha512-Uz3BxZWPgDwgHM2+vCKEQRh0R8WKrd/q6Tus1vThRClhlPO39Dyz7mDrOr6KuqGXAlBQ1e5Tnymzri4RMZNaWA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/api-logs": "0.202.0",
-        "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
+        "node": ">=14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -994,6 +964,18 @@
         "@opentelemetry/api": "^1.0.0"
       }
     },
+    "node_modules/@opentelemetry/propagator-aws-xray": {
+      "version": "1.26.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-aws-xray/-/propagator-aws-xray-1.26.2.tgz",
+      "integrity": "sha512-k43wxTjKYvwfce9L4eT8fFYy/ATmCfPHZPZsyT/6ABimf2KE1HafoOsIcxLOtmNSZt6dCvBIYCrXaOWta20xJg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
     "node_modules/@opentelemetry/propagator-b3": {
       "version": "1.30.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-1.30.1.tgz",
@@ -1255,9 +1237,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@splunk/otel": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-3.2.0.tgz",
-      "integrity": "sha512-UwtSdnuAxg28oHiPJjvBIugSxIBRIX0EoAFlaDG29pTeTWrY/qAYMnfwEddwVt3Hj3dVFnRzaA1xNBMgbUOL3A==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@splunk/otel/-/otel-3.3.0.tgz",
+      "integrity": "sha512-j/bPvE7/S6BDzTLMLKEoWZDIU3QDSvd2Vk+eX94/NQQ2/x5vWNrxcSNdU2GPABOCrMDLEWCxWi2iVlBmeuoF6g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1309,6 +1291,7 @@
         "@opentelemetry/instrumentation-tedious": "0.18.1",
         "@opentelemetry/instrumentation-undici": "0.10.1",
         "@opentelemetry/instrumentation-winston": "0.44.1",
+        "@opentelemetry/propagator-aws-xray": "1.26.2",
         "@opentelemetry/propagator-b3": "1.30.1",
         "@opentelemetry/resource-detector-container": "0.6.1",
         "@opentelemetry/resources": "1.30.1",
@@ -1414,12 +1397,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
       "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/signalfx": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@types/signalfx/-/signalfx-7.4.5.tgz",
-      "integrity": "sha512-VTV2vjyVIDCCbRCFN3Zx1EyoD9zyBSy5AKKmzS9iyWLecdmT8e+6Xn9TdZa4+ocWB+Zzoi2sSTFJWjCfFn2ZOw==",
       "license": "MIT"
     },
     "node_modules/@types/tedious": {

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -29,10 +29,9 @@
     "typescript": "5.8"
   },
   "dependencies": {
-    "@opentelemetry/instrumentation-aws-lambda": "0.53.0",
+    "@opentelemetry/instrumentation-aws-lambda": "0.50.3",
     "@opentelemetry/resource-detector-aws": "1.12.0",
     "@opentelemetry/sdk-trace-node": "1.30.1",
-    "@splunk/otel": "3.2.0",
-    "@types/signalfx": "7.4.5"
+    "@splunk/otel": "3.3.0"
   }
 }


### PR DESCRIPTION
* `@splunk/otel` - `xray` can now be set for `OTEL_PROPAGATORS`, disabled by default.
* Downgraded `@opentelemetry/instrumentation-aws-lambda` as the new versions make use of JS SDK 2.0, which brings in a semconv incompatible `@opentelemetry/instrumentation` causing the [instrumentation](https://github.com/open-telemetry/opentelemetry-js/blob/main/experimental/packages/opentelemetry-instrumentation/src/platform/node/RequireInTheMiddleSingleton.ts) to be loaded twice and most likely cause disjoint spans from the AWS Lambda instrumentation.
* Removed `@types/signalfx` from the dependencies, seems like they're not used anywhere.