### PR TITLE
Python tweak to remove pkg_resources dependency

### DIFF
--- a/python/src/splunk_lambda/__init__.py
+++ b/python/src/splunk_lambda/__init__.py
@@ -14,17 +14,16 @@
 
 from os import environ
 import logging
+import sys
 
 logger = logging.getLogger(__file__)
-
 
 def splunk_lambda_sls_zip_handler():
     if environ.get("SPLUNK_LAMBDA_SLS_ZIP", "false") == 'true':
         try:
-            logger.info("Trying to import dependencies")
+            logger.info("Trying to import unzip_requirements")
             import unzip_requirements
-            import pkg_resources
-            pkg_resources.working_set.add_entry("/tmp/sls-py-req")
+            sys.path.insert(0, "/tmp/sls-py-req")
             logger.info("unzip_requirements imported")
         except ImportError:
             logger.exception("Could not import unzip_requirements")


### PR DESCRIPTION
Stop using `pkg_resources` and use a `sys` variant instead to avoid the headaches of supporting a range of versions while `pkg_resources` is deprecated.