### PR TITLE
Update multiple components for upstream drift

### DIFF
--- a/java/build-layer.sh
+++ b/java/build-layer.sh
@@ -37,7 +37,7 @@ sed -i '3isource /opt/splunk-java-config' otel-stream-handler
 sed -i '3isource /opt/splunk-java-config' otel-proxy-handler
 sed -i '3isource /opt/splunk-java-config' otel-sqs-handler
 # proxy handler has one more special change
-sed -i 's/io.opentelemetry.instrumentation.awslambdaevents.v2_2.TracingRequestApiGatewayWrapper/com.splunk.support.lambda.TracingRequestApiGatewayWrapper/g' otel-proxy-handler
+sed -i 's/io.opentelemetry.instrumentation.awslambdaevents.v3_11.TracingRequestApiGatewayWrapper/com.splunk.support.lambda.TracingRequestApiGatewayWrapper/g' otel-proxy-handler
 
 popd
 

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -8,8 +8,7 @@ description = "Splunk distribution of OpenTelemetry Lambda"
 
 ext {
     versions = [
-            opentelemetry: '2.0.0',
-            opentelemetryalpha: '2.25.0-alpha'
+            opentelemetryalpha: '2.26.1-alpha'
     ]
 }
 
@@ -37,7 +36,8 @@ dependencies {
     compileOnly("io.opentelemetry:opentelemetry-api")
     compileOnly("io.opentelemetry:opentelemetry-sdk-extension-autoconfigure")
     // AWS
-    compileOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-events-2.2")
+    compileOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-core-1.0")
+    compileOnly("io.opentelemetry.instrumentation:opentelemetry-aws-lambda-events-3.11")
     // exporters
     compileOnly("io.opentelemetry:opentelemetry-exporter-logging")
     implementation("io.opentelemetry:opentelemetry-exporter-otlp")

--- a/java/src/main/java/com/splunk/support/lambda/TracingRequestApiGatewayWrapper.java
+++ b/java/src/main/java/com/splunk/support/lambda/TracingRequestApiGatewayWrapper.java
@@ -23,7 +23,7 @@ import io.opentelemetry.context.propagation.TextMapSetter;
 import java.util.HashMap;
 
 public class TracingRequestApiGatewayWrapper
-    extends io.opentelemetry.instrumentation.awslambdaevents.v2_2.TracingRequestApiGatewayWrapper {
+    extends io.opentelemetry.instrumentation.awslambdaevents.v3_11.TracingRequestApiGatewayWrapper {
 
   @Override
   protected APIGatewayProxyResponseEvent doHandleRequest(

--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -12,9 +12,9 @@ sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==2.9.0/g' requiremen
 # Add the logging dependency below the opentelemetry-instrumentation dependency
 sed -i '/^opentelemetry-instrumentation==/a opentelemetry-instrumentation-logging==0.60b1' requirements.txt
 # Even if these regexes do nothing, leave these lines in to make later updates easier
-sed -i 's/0.60b1/0.60b1/g' nodeps-requirements.txt
-sed -i 's/0.60b1/0.60b1/g' requirements.txt
-sed -i 's/1.39.1/1.39.1/g' requirements.txt
+sed -i 's/0.61b0/0.60b1/g' nodeps-requirements.txt
+sed -i 's/0.61b0/0.60b1/g' requirements.txt
+sed -i 's/1.40.0/1.39.1/g' requirements.txt
 sed -i 's/^docker run --rm/docker run/g'  ../../build.sh
 sed -i '2isource /opt/splunk-default-config' otel-instrument
 


### PR DESCRIPTION
- (Separately, in lambda-layers) update collector build to go 1.26
- Update upstream submodule to latest
- Update java code and dependencies due to deprecation of the old lambda wrapper
- Update python versions