### PR TITLE
Update Python OTel layer dependencies

### DIFF
--- a/python/build-layer.sh
+++ b/python/build-layer.sh
@@ -3,25 +3,31 @@
 DISTRO_DIR=build
 SOURCES_DIR=otel/otel_sdk
 OTEL_PYTHON_DIR=../opentelemetry-lambda/python/src
+SPLUNK_OTEL_VERSION=2.11.0
+OTEL_SDK_VERSION=1.42.1
+OTEL_INSTRUMENTATION_VERSION=0.63b1
+PYTHON_RUNTIME=python3.10
 
 echo "Modify dependencies and script for Splunk integration"
 pushd "$OTEL_PYTHON_DIR"
 
 cd "$SOURCES_DIR"
-sed -i 's/^opentelemetry-distro.*/splunk-opentelemetry[all]==2.10.1/g' requirements.txt
+sed -i "s/^opentelemetry-distro.*/splunk-opentelemetry[all]==${SPLUNK_OTEL_VERSION}/g" requirements.txt
 # Add the logging dependency below the opentelemetry-instrumentation dependency
-sed -i '/^opentelemetry-instrumentation==/a opentelemetry-instrumentation-logging==0.62b0' requirements.txt
+sed -i "/^opentelemetry-instrumentation==/a opentelemetry-instrumentation-logging==${OTEL_INSTRUMENTATION_VERSION}" requirements.txt
 # Even if these regexes do nothing, leave these lines in to make later updates easier
-sed -i 's/0.62b0/0.62b0/g' nodeps-requirements.txt
-sed -i 's/0.62b0/0.62b0/g' requirements.txt
-sed -i 's/1.41.0/1.41.0/g' requirements.txt
+sed -i "s/==0\\.[0-9][0-9]b[0-9]$/==${OTEL_INSTRUMENTATION_VERSION}/g" nodeps-requirements.txt
+sed -i "s/==0\\.[0-9][0-9]b[0-9]$/==${OTEL_INSTRUMENTATION_VERSION}/g" requirements.txt
+sed -i "s/==1\\.[0-9][0-9]\\.[0-9]$/==${OTEL_SDK_VERSION}/g" requirements.txt
 sed -i 's/^docker run --rm/docker run/g'  ../../build.sh
 sed -i '2isource /opt/splunk-default-config' otel-instrument
 
 cd ../..
 
-# FIXME no good way to specify python version requirement to pip; use 3.9 runtime/setuptools image
-sed -i 's/runtime=python3.*/runtime=python3.9/' otel/Dockerfile
+# FIXME no good way to specify python version requirement to pip; use the minimum
+# runtime supported by splunk-opentelemetry.
+sed -i "s/runtime=python3.*/runtime=${PYTHON_RUNTIME}/" otel/Dockerfile
+sed -i -E "s#build-python3\\.[0-9]+:latest(@sha256:[0-9a-f]+)?#build-${PYTHON_RUNTIME}:latest#" otel/Dockerfile
 echo "Modified Dockerfile:"
 cat otel/Dockerfile
 echo "----"

--- a/python/src/splunk_lambda-1.0.0.dist-info/METADATA
+++ b/python/src/splunk_lambda-1.0.0.dist-info/METADATA
@@ -5,12 +5,12 @@ Summary: The Splunk extensions for Python lambda.
 License: Apache-2.0
 Author: Splunk
 Author-email: splunk-oss@splunk.com
-Requires-Python: >=3.6,<4.0
+Requires-Python: >=3.10,<4.0
 Classifier: License :: OSI Approved :: Apache Software License
 Classifier: Programming Language :: Python :: 3
 Classifier: Programming Language :: Python :: 3.10
-Classifier: Programming Language :: Python :: 3.6
-Classifier: Programming Language :: Python :: 3.7
-Classifier: Programming Language :: Python :: 3.8
-Classifier: Programming Language :: Python :: 3.9
+Classifier: Programming Language :: Python :: 3.11
+Classifier: Programming Language :: Python :: 3.12
+Classifier: Programming Language :: Python :: 3.13
+Classifier: Programming Language :: Python :: 3.14
 Provides-Extra: all


### PR DESCRIPTION
We moved the Python layer build minimum to Python 3.10 because the forward-compatible dependency fix requires splunk-opentelemetry==2.11.0.

The previous splunk-opentelemetry==2.10.1 line depends on opentelemetry-api==1.41.0, while upstream OpenTelemetry Lambda now pins OTel packages at 1.42.1. That mismatch causes pip’s resolver conflict.

splunk-opentelemetry==2.11.0 aligns with OTel 1.42.1, so it fixes the conflict by moving forward. However, 2.11.0 declares Requires-Python: >=3.10, so Python 3.9 is no longer a valid target for this dependency set.

Keeping Python 3.9 would require pinning OTel back to 1.41.0 and staying on splunk-opentelemetry==2.10.1, which is the backward-looking fix we wanted to avoid.